### PR TITLE
Fix used MacOS Version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-14, windows-latest ]
+        os: [ ubuntu-latest, macos-12, macos-14, windows-latest ]
         python-version: [ '3.10' ]
     runs-on: ${{ matrix.os }}
 
@@ -107,7 +107,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, macos-14, windows-latest ]
+        os: [ ubuntu-latest, macos-12, macos-14, windows-latest ]
         python-version: [ '3.10', '3.11' , '3.12']
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Use MacOS 12 for Intel builds and MacOS 14 for ARM builds

(cherry picked from commit 3399b1bb62267a6dda49850be6e7c9b9602b1986)