### PR TITLE
Fetch git tags to get the correct version for stable and latest

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,10 @@ build:
       - sleep 60 # sleep for Zenodo upload to finsih
       - python scripts/generate_bibtex.py
 
+    post_checkout:
+      # we need the tags for versioning to work
+      - git fetch --tags
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
@@ -28,4 +32,3 @@ formats: all
 python:
    install:
    - requirements: docs/requirements.txt
-

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,24 @@
 Changelog
 *********
 
+Version 1.1.2 (2024-06-16)
+==========================
+
+**Fixes:**
+
+- Improve documentation: Show BibTeX for citation from Zenodo metadata (also for stable)
+
+Version 1.1.1 (2024-06-12)
+==========================
+
+**Fixes:**
+
+- Improve plotting of polygons:
+    * Fill color of polygons does not show outside of the borders when using narraw :code:`line_width`
+    * No gaps at the last point of the polygon boundary
+- Improve documentation: Show BibTeX for citation from Zenodo metadata
+
+
 Version 1.1.0 (2024-03-13)
 ==========================
 


### PR DESCRIPTION
When readthedocs builds the documentation for the stable page doesn't fetch the tags from the repo. Without the tags the current version can not be detected automatically when installing PedPy, it will be set to the default version (0.0.0). For this version is no Zenodo information available. With this workaround the tags will be fetched during the check out process in the readthedocs build process.

Closes #357 
