### PR TITLE
Fix distance to time plot

### DIFF
--- a/pedpy/plotting/plotting.py
+++ b/pedpy/plotting/plotting.py
@@ -504,7 +504,6 @@ def plot_time_distance(
     *,
     time_distance: pd.DataFrame,
     speed: Optional[pd.DataFrame] = None,
-    frame_rate: float,
     axes: Optional[matplotlib.axes.Axes] = None,
     **kwargs: Any,
 ) -> matplotlib.axes.Axes:
@@ -517,7 +516,6 @@ def plot_time_distance(
         time_distance (pd.DataFrame): DataFrame containing information on time and
             distance to some target
         speed (pd.DataFrame): DataFrame containing speed calculation.
-        frame_rate(float): frame_rate of the trajectory
         axes (matplotlib.axes.Axes): Axes to plot on, if None new will be created
         marker_color (optional): color of the markers on the plot
         line_color (optional): color of the lines on the plot
@@ -560,7 +558,7 @@ def plot_time_distance(
         min_data = ped_data[ped_data.frame == ped_data.frame.min()]
         axes.scatter(
             min_data.distance,
-            min_data.time_seconds,
+            min_data.time,
             color=color,
             s=5,
             marker="o",
@@ -584,7 +582,7 @@ def plot_time_distance(
         min_data = ped_data[ped_data.frame == ped_data.frame.min()]
         axes.scatter(
             min_data.distance,
-            min_data.time_seconds,
+            min_data.time,
             c=min_data.speed,
             cmap="jet",
             norm=norm,
@@ -606,7 +604,7 @@ def plot_time_distance(
         """
         axes.plot(
             ped_data.distance,
-            ped_data.time_seconds,
+            ped_data.time,
             color=color,
             alpha=0.7,
             lw=0.25,
@@ -625,7 +623,7 @@ def plot_time_distance(
         norm: Normalization for the colormap based on speed.
         cmap: The colormap to use for coloring the line based on speed.
         """
-        points = ped_data[["distance", "time_seconds"]].to_numpy()
+        points = ped_data[["distance", "time"]].to_numpy()
         speed_id = ped_data.speed.to_numpy()
         segments = [
             [
@@ -712,7 +710,6 @@ def plot_time_distance(
 
     axes = axes or plt.gca()
     _setup_plot(axes, **kwargs)
-    time_distance["time_seconds"] = time_distance.time / frame_rate
     if speed is not None:
         _plot_with_speed_colors(axes, time_distance, speed)
     else:


### PR DESCRIPTION
During the plotting the time was divided by the frame rate, which is not needed here. This resulted in wrong times displayed in the plot. Removed the wrong division.