### PR TITLE
fix plot of Voronoi-Cells

### DIFF
--- a/pedpy/plotting/plotting.py
+++ b/pedpy/plotting/plotting.py
@@ -55,6 +55,7 @@ def _plot_polygon(
     line_width: float = 1,
     hole_color: Any = "lightgrey",
     hole_alpha: float = 1,
+    zorder: float = 1000,
 ) -> matplotlib.axes.Axes:
     """Plot the shapely polygon (including holes).
 
@@ -68,6 +69,8 @@ def _plot_polygon(
         line_width (float): line width of the borders
         hole_color (Any): background color of holes
         hole_alpha (float): alpha of background color for holes
+        zorder (float): Specifies the drawing order of the polygon,
+            lower values are drawn first
 
     Returns:
         matplotlib.axes.Axes instance where the polygon is plotted
@@ -84,7 +87,7 @@ def _plot_polygon(
         facecolor="none",
         linewidth=line_width,
         closed=True,
-        zorder=1000,
+        zorder=zorder,
     )
     axes.add_patch(exterior_polygon_border)
 
@@ -95,7 +98,7 @@ def _plot_polygon(
         linewidth=line_width,
         alpha=polygon_alpha,
         closed=True,
-        zorder=1000,
+        zorder=zorder,
     )
     axes.add_patch(exterior_polygon_fill)
 
@@ -109,7 +112,7 @@ def _plot_polygon(
             linewidth=line_width,
             alpha=1,
             closed=True,
-            zorder=1000,
+            zorder=zorder,
         )
         axes.add_patch(interior_polygon_border)
 
@@ -120,7 +123,7 @@ def _plot_polygon(
             linewidth=line_width,
             alpha=hole_alpha,
             closed=True,
-            zorder=1000,
+            zorder=zorder,
         )
         axes.add_patch(interior_polygon_fill)
 
@@ -1180,6 +1183,7 @@ def plot_voronoi_cells(  # noqa: PLR0912,PLR0915
             line_color=voronoi_border_color,
             polygon_color=color,
             polygon_alpha=voronoi_outside_ma_alpha,
+            zorder=1,
         )
 
         if INTERSECTION_COL in data.columns:
@@ -1191,6 +1195,7 @@ def plot_voronoi_cells(  # noqa: PLR0912,PLR0915
                     line_color="none",
                     polygon_color=color,
                     polygon_alpha=voronoi_inside_ma_alpha,
+                    zorder=1,
                 )
 
         if traj_data:


### PR DESCRIPTION
currently the position of pedestrian is not displayed when plotting the Voronoi-Cells.
![voronoi_without_pos](https://github.com/user-attachments/assets/96e554ec-5bd6-4b0a-ab56-623c67aaad41)
This can be seen in the picture above.

This is because the [zorder](https://matplotlib.org/3.1.1/gallery/misc/zorder_demo.html) is set to 1000 when plotting the cells. 
If the positions of the pedestrians are then plotted, they are not visible. 
This pull request adds the zorder attribute with the default 1000 to the helper method that plots a polygon. When this helper method is called when plotting the Voronoi cells, the zorder attribute is explicitly set to 1. 
This ensures that the position of the pedestrians plotted afterwards is displayed correctly. Other plot functions that use the helper method are not affected by these changes, as the default value is set to 1000.
![voronoi_with_pos](https://github.com/user-attachments/assets/d1794109-3cf4-4bf4-a6a3-242ee15c27f0)

The picture above shows the result of the voronoi-cell plot in the user guide after these changes.
