### PR TITLE
Update the MacOs runner in our CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24.04 ]
         python-version: [ '3.11' ]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14, macos-15, windows-latest ]
+        os: [ ubuntu-24.04, macos-13, macos-14, macos-15, windows-latest ]
         python-version: [ '3.11' ]
     runs-on: ${{ matrix.os }}
 
@@ -88,19 +88,19 @@ jobs:
 
       - name: Build wheel
         id: build-wheel
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         run: |
           python3 -m build
 
       - name: Upload wheel as artifact
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
 
       - name: Upload notebooks and demo files as artifacts
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         uses: actions/upload-artifact@v4
         with:
           name: demos_usage
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-14, macos-15, windows-latest ]
+        os: [ ubuntu-24.04, macos-13, macos-14, macos-15, windows-latest ]
         python-version: [ '3.11', '3.12' , '3.13']
     runs-on: ${{ matrix.os }}
 
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24.04 ]
         python-version: [ '3.11' ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-14, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14, macos-15, windows-latest ]
         python-version: [ '3.11' ]
     runs-on: ${{ matrix.os }}
 
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-12, macos-14, windows-latest ]
+        os: [ ubuntu-latest, macos-13, macos-14, macos-15, windows-latest ]
         python-version: [ '3.11', '3.12' , '3.13']
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
As the MacOS 12 GitHub Action runner is no longer supported, we use more up-to-date versions in our CI. Also the version of the Ubuntu runner is now specified to get a better control, on what is used here.