### PR TITLE
Use codecov only for informational purposes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
+        if: matrix.os == 'ubuntu-24.04'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,10 +6,12 @@ coverage:
       default:
         target: auto
         threshold: 50%  # Allow more fluctuation
+        informational: true  # Do not fail CI; only provide information
     patch:
       default:
         target: auto
         threshold: 10%  # Stricter for new changes
+        informational: true  # Do not fail CI; only provide information
 
 comment:
   layout: "condensed_header, condensed_files, condensed_footer" # add "condensed_" to "header", "files" and "footer"


### PR DESCRIPTION
The code coverage for a new patch/change is only shown for
informational purposes. It should not block any PR, rather it should be
a point to discuss if some tests are needed.

Also, only upload the coverage data from one of the tests runs, as they should be the same and not depend on the hardware/OS the test is run.
