### PR TITLE
Fix CI dependencies and update hdf5 depdendecy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.8
+    rev: v0.8.3
     hooks:
       - id: ruff
         alias: ruff-include-sorting
@@ -15,7 +15,7 @@ repos:
         files: ^pedpy/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2  # Use the latest version of mypy available at the time
+    rev: v1.13.0  # Use the latest version of mypy available at the time
     hooks:
       - id: mypy
         name: Check type hints (mypy)

--- a/pedpy/__init__.py
+++ b/pedpy/__init__.py
@@ -116,7 +116,7 @@ from .plotting.plotting import (
     plot_walkable_area,
 )
 
-__all__ = [
+__all__ = [  # noqa: RUF022 disable sorting of __all__ for better maintenance
     "MeasurementArea",
     "MeasurementLine",
     "WalkableArea",

--- a/pedpy/methods/profile_calculator.py
+++ b/pedpy/methods/profile_calculator.py
@@ -12,7 +12,7 @@ in which the mean speed and density can be computed with different methods.
 """
 
 from enum import Enum, auto
-from typing import Any, Final, List, Optional, Tuple
+from typing import Any, Final, Optional, Sequence, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -167,8 +167,8 @@ def compute_profiles(  # noqa: D417
     # pylint: disable=unused-argument,too-many-arguments
     **kwargs: Any,
 ) -> Tuple[
-    List[npt.NDArray[np.float64]],
-    List[npt.NDArray[np.float64]],
+    Sequence[npt.NDArray[np.float64]],
+    Sequence[npt.NDArray[np.float64]],
 ]:
     """Computes the density and speed profiles.
 
@@ -260,7 +260,7 @@ def compute_density_profile(
     grid_intersections_area: Optional[npt.NDArray[np.float64]] = None,
     gaussian_width: Optional[float] = None,
     # pylint: disable=too-many-arguments
-) -> List[npt.NDArray[np.float64]]:
+) -> Sequence[npt.NDArray[np.float64]]:
     """Compute the density profile.
 
     Args:
@@ -484,7 +484,7 @@ def compute_speed_profile(
     fill_value: float = np.nan,
     gaussian_width: float = 0.5,
     # pylint: disable=too-many-arguments
-) -> List[npt.NDArray[np.float64]]:
+) -> Sequence[npt.NDArray[np.float64]]:
     """Computes the speed profile for pedestrians within an area.
 
     This function calculates speed profiles based on pedestrian speed data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "Shapely~=2.0.6",
     "scipy~=1.14",
     "matplotlib~=3.9",
-    "h5py~=3.11",
+    "h5py~=3.12",
 ]
 
 requires-python = ">=3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas~=2.2.3
 Shapely~=2.0.6
 scipy~=1.14
 matplotlib~=3.9
-h5py~=3.11.0
+h5py~=3.12
 
 # testing
 pytest~=8.3
@@ -16,7 +16,7 @@ click~=8.1
 build~=1.1
 
 # ci
-mypy~=1.11
+mypy==1.13
 mypy-extensions==1.0
-ruff~=0.6
-pre-commit~=3.8
+ruff==0.8
+pre-commit==4.0


### PR DESCRIPTION
- Fix the CI dependencies to a specific version, to avoid unexpected failures in nightly builds
- Update hdf5 to a version which offers wheels for Python 3.13