### PR TITLE
Remove redundant "Pedestrian Dynamics" from section title

### DIFF
--- a/notebooks/user_guide.ipynb
+++ b/notebooks/user_guide.ipynb
@@ -3574,7 +3574,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Pedestrian Dynamics : Spatial Analysis \n",
+    "### Spatial Analysis \n",
     "This section corresponds to analysis method which can be used to characterise different crowds or group formations.\n",
     "These methods may include measurement of the time-to-collision, pair-distribution function and measurement of crowd polarization.\n"
    ]
@@ -3583,7 +3583,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Pair-distribution function (PDF)\n",
+    "#### Pair-distribution function (PDF)\n",
     "\n",
     "This method is inspired from condensed matter description and used in the work of [Cordes et al. (2023)](https://doi.org/10.1093/pnasnexus/pgae120) following [Karamousas et al. (2014)](https://doi.org/10.1103/PhysRevLett.113.238701).\n",
     "The pair-distribution function (PDF): \n",
@@ -3638,7 +3638,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Parameters of the PDF\n",
+    "##### Parameters of the PDF\n",
     "\n",
     "The function `compute_pair_distribution_function` has two main parameters:\n",
     "\n",


### PR DESCRIPTION
As PedPy is designed for pedestrian dynamics there is no need to mention it specifically in the section title. Also move the section a subsection of the analysis section.