### PR TITLE
Update setup tools to latest version (1.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = ">=3.11"
 homepage = "https://pedpy.readthedocs.io/"
 
 [build-system]
-requires = ["setuptools>=42", "wheel", "versioningit"]
+requires = ["setuptools>=75", "wheel", "versioningit"]
 build-backend = "setuptools.build_meta"
 
 [tool.versioningit.vcs]


### PR DESCRIPTION
When uploading to PyPI a deprecation warning was sent, stating that the binary file name did not contain the normalized project name "pedpy". This is solved by using a more modern version of the setuptools.

For checking if correctly, the `dist` artifact of the ci run should contain a `pedpy-1.4.0.dev2-py3-none-any.whl`-file