### PR TITLE
Better dependabot handling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,28 @@
 version: 2
 updates:
-  # Check for updates to Python dependencies
   - package-ecosystem: "pip"
-    directory: "/" # Root directory of the repository
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      general-dependencies:
+        patterns:
+          - "*"
+    allow:
+      - dependency-type: "all"
     ignore:
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "pandas"
         update-types: ["version-update:semver-major"]
-
-  # Check for updates to GitHub Actions
+        
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
Instead of creating one PR per updated dependency now one PR per week (if there are updates) is created.

Example PR: https://github.com/schroedtert/PedPy/pull/26