### PR TITLE
Change dependabot interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       general-dependencies:
         patterns:
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       github-actions-dependencies:
         patterns:


### PR DESCRIPTION
To avoid getting spammed with dependabot PRs and as we do not need to be that cutting-edge with our dependencies, we move to a monthly update of the dependencies.

Closes #451 