### PR TITLE
Profiles for measurement area

### DIFF
--- a/docs/source/images/axis_aligned_measurement_area_from_ma.svg
+++ b/docs/source/images/axis_aligned_measurement_area_from_ma.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="371.52pt" height="229.371655pt" viewBox="0 0 371.52 229.371655" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-08-10T10:38:25.449132</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 229.371655 
+L 371.52 229.371655 
+L 371.52 -0 
+L 0 -0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 43.626702 209.654447 
+L 351.802792 155.314688 
+L 327.893298 19.717208 
+L 19.717208 74.056968 
+L 43.626702 209.654447 
+" clip-path="url(#p6937e1a6e3)" style="fill: #59b2d8; opacity: 0.7; stroke: #59b2d8; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 351.802792 209.654447 
+L 351.802792 19.717208 
+L 19.717208 19.717208 
+L 19.717208 209.654447 
+L 351.802792 209.654447 
+" clip-path="url(#p6937e1a6e3)" style="fill: #e97586; opacity: 0.2; stroke: #e97586; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p6937e1a6e3">
+   <rect x="7.2" y="7.2" width="357.12" height="214.971655"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/source/images/profile_axis_aligned_measurement_area_with_grid.svg
+++ b/docs/source/images/profile_axis_aligned_measurement_area_with_grid.svg
@@ -1,0 +1,7823 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="371.52pt" height="229.371655pt" viewBox="0 0 371.52 229.371655" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-08-10T10:45:53.077375</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 229.371655 
+L 371.52 229.371655 
+L 371.52 -0 
+L 0 -0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 351.802792 209.654447 
+L 351.802792 19.717208 
+L 19.717208 19.717208 
+L 19.717208 209.654447 
+L 351.802792 209.654447 
+" clip-path="url(#p9ee2866781)" style="fill: #e97586; opacity: 0.2; stroke: #e97586; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 32.234416 19.717208 
+L 32.234416 32.234416 
+L 19.717208 32.234416 
+L 19.717208 19.717208 
+L 32.234416 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 32.234416 19.717208 
+L 32.234416 32.234416 
+L 19.717208 32.234416 
+L 19.717208 19.717208 
+L 32.234416 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 44.751624 19.717208 
+L 44.751624 32.234416 
+L 32.234416 32.234416 
+L 32.234416 19.717208 
+L 44.751624 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 44.751624 19.717208 
+L 44.751624 32.234416 
+L 32.234416 32.234416 
+L 32.234416 19.717208 
+L 44.751624 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 57.268832 19.717208 
+L 57.268832 32.234416 
+L 44.751624 32.234416 
+L 44.751624 19.717208 
+L 57.268832 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 57.268832 19.717208 
+L 57.268832 32.234416 
+L 44.751624 32.234416 
+L 44.751624 19.717208 
+L 57.268832 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 69.786041 19.717208 
+L 69.786041 32.234416 
+L 57.268832 32.234416 
+L 57.268832 19.717208 
+L 69.786041 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 69.786041 19.717208 
+L 69.786041 32.234416 
+L 57.268832 32.234416 
+L 57.268832 19.717208 
+L 69.786041 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 82.303249 19.717208 
+L 82.303249 32.234416 
+L 69.786041 32.234416 
+L 69.786041 19.717208 
+L 82.303249 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 82.303249 19.717208 
+L 82.303249 32.234416 
+L 69.786041 32.234416 
+L 69.786041 19.717208 
+L 82.303249 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 94.820457 19.717208 
+L 94.820457 32.234416 
+L 82.303249 32.234416 
+L 82.303249 19.717208 
+L 94.820457 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 94.820457 19.717208 
+L 94.820457 32.234416 
+L 82.303249 32.234416 
+L 82.303249 19.717208 
+L 94.820457 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 107.337665 19.717208 
+L 107.337665 32.234416 
+L 94.820457 32.234416 
+L 94.820457 19.717208 
+L 107.337665 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 107.337665 19.717208 
+L 107.337665 32.234416 
+L 94.820457 32.234416 
+L 94.820457 19.717208 
+L 107.337665 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 119.854873 19.717208 
+L 119.854873 32.234416 
+L 107.337665 32.234416 
+L 107.337665 19.717208 
+L 119.854873 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 119.854873 19.717208 
+L 119.854873 32.234416 
+L 107.337665 32.234416 
+L 107.337665 19.717208 
+L 119.854873 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 132.372081 19.717208 
+L 132.372081 32.234416 
+L 119.854873 32.234416 
+L 119.854873 19.717208 
+L 132.372081 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 132.372081 19.717208 
+L 132.372081 32.234416 
+L 119.854873 32.234416 
+L 119.854873 19.717208 
+L 132.372081 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 144.889289 19.717208 
+L 144.889289 32.234416 
+L 132.372081 32.234416 
+L 132.372081 19.717208 
+L 144.889289 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 144.889289 19.717208 
+L 144.889289 32.234416 
+L 132.372081 32.234416 
+L 132.372081 19.717208 
+L 144.889289 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 157.406497 19.717208 
+L 157.406497 32.234416 
+L 144.889289 32.234416 
+L 144.889289 19.717208 
+L 157.406497 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 157.406497 19.717208 
+L 157.406497 32.234416 
+L 144.889289 32.234416 
+L 144.889289 19.717208 
+L 157.406497 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 169.923705 19.717208 
+L 169.923705 32.234416 
+L 157.406497 32.234416 
+L 157.406497 19.717208 
+L 169.923705 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 169.923705 19.717208 
+L 169.923705 32.234416 
+L 157.406497 32.234416 
+L 157.406497 19.717208 
+L 169.923705 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 182.440913 19.717208 
+L 182.440913 32.234416 
+L 169.923705 32.234416 
+L 169.923705 19.717208 
+L 182.440913 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 182.440913 19.717208 
+L 182.440913 32.234416 
+L 169.923705 32.234416 
+L 169.923705 19.717208 
+L 182.440913 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 194.958122 19.717208 
+L 194.958122 32.234416 
+L 182.440913 32.234416 
+L 182.440913 19.717208 
+L 194.958122 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 194.958122 19.717208 
+L 194.958122 32.234416 
+L 182.440913 32.234416 
+L 182.440913 19.717208 
+L 194.958122 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 207.47533 19.717208 
+L 207.47533 32.234416 
+L 194.958122 32.234416 
+L 194.958122 19.717208 
+L 207.47533 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 207.47533 19.717208 
+L 207.47533 32.234416 
+L 194.958122 32.234416 
+L 194.958122 19.717208 
+L 207.47533 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 219.992538 19.717208 
+L 219.992538 32.234416 
+L 207.47533 32.234416 
+L 207.47533 19.717208 
+L 219.992538 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 219.992538 19.717208 
+L 219.992538 32.234416 
+L 207.47533 32.234416 
+L 207.47533 19.717208 
+L 219.992538 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 232.509746 19.717208 
+L 232.509746 32.234416 
+L 219.992538 32.234416 
+L 219.992538 19.717208 
+L 232.509746 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 232.509746 19.717208 
+L 232.509746 32.234416 
+L 219.992538 32.234416 
+L 219.992538 19.717208 
+L 232.509746 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 245.026954 19.717208 
+L 245.026954 32.234416 
+L 232.509746 32.234416 
+L 232.509746 19.717208 
+L 245.026954 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 245.026954 19.717208 
+L 245.026954 32.234416 
+L 232.509746 32.234416 
+L 232.509746 19.717208 
+L 245.026954 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 257.544162 19.717208 
+L 257.544162 32.234416 
+L 245.026954 32.234416 
+L 245.026954 19.717208 
+L 257.544162 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 257.544162 19.717208 
+L 257.544162 32.234416 
+L 245.026954 32.234416 
+L 245.026954 19.717208 
+L 257.544162 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 270.06137 19.717208 
+L 270.06137 32.234416 
+L 257.544162 32.234416 
+L 257.544162 19.717208 
+L 270.06137 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 270.06137 19.717208 
+L 270.06137 32.234416 
+L 257.544162 32.234416 
+L 257.544162 19.717208 
+L 270.06137 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 282.578578 19.717208 
+L 282.578578 32.234416 
+L 270.06137 32.234416 
+L 270.06137 19.717208 
+L 282.578578 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 282.578578 19.717208 
+L 282.578578 32.234416 
+L 270.06137 32.234416 
+L 270.06137 19.717208 
+L 282.578578 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 295.095786 19.717208 
+L 295.095786 32.234416 
+L 282.578578 32.234416 
+L 282.578578 19.717208 
+L 295.095786 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 295.095786 19.717208 
+L 295.095786 32.234416 
+L 282.578578 32.234416 
+L 282.578578 19.717208 
+L 295.095786 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 307.612994 19.717208 
+L 307.612994 32.234416 
+L 295.095786 32.234416 
+L 295.095786 19.717208 
+L 307.612994 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 307.612994 19.717208 
+L 307.612994 32.234416 
+L 295.095786 32.234416 
+L 295.095786 19.717208 
+L 307.612994 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 320.130203 19.717208 
+L 320.130203 32.234416 
+L 307.612994 32.234416 
+L 307.612994 19.717208 
+L 320.130203 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 320.130203 19.717208 
+L 320.130203 32.234416 
+L 307.612994 32.234416 
+L 307.612994 19.717208 
+L 320.130203 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 332.647411 19.717208 
+L 332.647411 32.234416 
+L 320.130203 32.234416 
+L 320.130203 19.717208 
+L 332.647411 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 332.647411 19.717208 
+L 332.647411 32.234416 
+L 320.130203 32.234416 
+L 320.130203 19.717208 
+L 332.647411 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 345.164619 19.717208 
+L 345.164619 32.234416 
+L 332.647411 32.234416 
+L 332.647411 19.717208 
+L 345.164619 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_54">
+    <path d="M 345.164619 19.717208 
+L 345.164619 32.234416 
+L 332.647411 32.234416 
+L 332.647411 19.717208 
+L 345.164619 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_55">
+    <path d="M 357.681827 19.717208 
+L 357.681827 32.234416 
+L 345.164619 32.234416 
+L 345.164619 19.717208 
+L 357.681827 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_56">
+    <path d="M 357.681827 19.717208 
+L 357.681827 32.234416 
+L 345.164619 32.234416 
+L 345.164619 19.717208 
+L 357.681827 19.717208 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_57">
+    <path d="M 32.234416 32.234416 
+L 32.234416 44.751624 
+L 19.717208 44.751624 
+L 19.717208 32.234416 
+L 32.234416 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_58">
+    <path d="M 32.234416 32.234416 
+L 32.234416 44.751624 
+L 19.717208 44.751624 
+L 19.717208 32.234416 
+L 32.234416 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_59">
+    <path d="M 44.751624 32.234416 
+L 44.751624 44.751624 
+L 32.234416 44.751624 
+L 32.234416 32.234416 
+L 44.751624 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_60">
+    <path d="M 44.751624 32.234416 
+L 44.751624 44.751624 
+L 32.234416 44.751624 
+L 32.234416 32.234416 
+L 44.751624 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_61">
+    <path d="M 57.268832 32.234416 
+L 57.268832 44.751624 
+L 44.751624 44.751624 
+L 44.751624 32.234416 
+L 57.268832 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_62">
+    <path d="M 57.268832 32.234416 
+L 57.268832 44.751624 
+L 44.751624 44.751624 
+L 44.751624 32.234416 
+L 57.268832 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_63">
+    <path d="M 69.786041 32.234416 
+L 69.786041 44.751624 
+L 57.268832 44.751624 
+L 57.268832 32.234416 
+L 69.786041 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_64">
+    <path d="M 69.786041 32.234416 
+L 69.786041 44.751624 
+L 57.268832 44.751624 
+L 57.268832 32.234416 
+L 69.786041 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_65">
+    <path d="M 82.303249 32.234416 
+L 82.303249 44.751624 
+L 69.786041 44.751624 
+L 69.786041 32.234416 
+L 82.303249 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_66">
+    <path d="M 82.303249 32.234416 
+L 82.303249 44.751624 
+L 69.786041 44.751624 
+L 69.786041 32.234416 
+L 82.303249 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_67">
+    <path d="M 94.820457 32.234416 
+L 94.820457 44.751624 
+L 82.303249 44.751624 
+L 82.303249 32.234416 
+L 94.820457 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_68">
+    <path d="M 94.820457 32.234416 
+L 94.820457 44.751624 
+L 82.303249 44.751624 
+L 82.303249 32.234416 
+L 94.820457 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_69">
+    <path d="M 107.337665 32.234416 
+L 107.337665 44.751624 
+L 94.820457 44.751624 
+L 94.820457 32.234416 
+L 107.337665 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_70">
+    <path d="M 107.337665 32.234416 
+L 107.337665 44.751624 
+L 94.820457 44.751624 
+L 94.820457 32.234416 
+L 107.337665 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_71">
+    <path d="M 119.854873 32.234416 
+L 119.854873 44.751624 
+L 107.337665 44.751624 
+L 107.337665 32.234416 
+L 119.854873 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_72">
+    <path d="M 119.854873 32.234416 
+L 119.854873 44.751624 
+L 107.337665 44.751624 
+L 107.337665 32.234416 
+L 119.854873 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_73">
+    <path d="M 132.372081 32.234416 
+L 132.372081 44.751624 
+L 119.854873 44.751624 
+L 119.854873 32.234416 
+L 132.372081 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_74">
+    <path d="M 132.372081 32.234416 
+L 132.372081 44.751624 
+L 119.854873 44.751624 
+L 119.854873 32.234416 
+L 132.372081 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_75">
+    <path d="M 144.889289 32.234416 
+L 144.889289 44.751624 
+L 132.372081 44.751624 
+L 132.372081 32.234416 
+L 144.889289 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_76">
+    <path d="M 144.889289 32.234416 
+L 144.889289 44.751624 
+L 132.372081 44.751624 
+L 132.372081 32.234416 
+L 144.889289 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_77">
+    <path d="M 157.406497 32.234416 
+L 157.406497 44.751624 
+L 144.889289 44.751624 
+L 144.889289 32.234416 
+L 157.406497 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_78">
+    <path d="M 157.406497 32.234416 
+L 157.406497 44.751624 
+L 144.889289 44.751624 
+L 144.889289 32.234416 
+L 157.406497 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_79">
+    <path d="M 169.923705 32.234416 
+L 169.923705 44.751624 
+L 157.406497 44.751624 
+L 157.406497 32.234416 
+L 169.923705 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_80">
+    <path d="M 169.923705 32.234416 
+L 169.923705 44.751624 
+L 157.406497 44.751624 
+L 157.406497 32.234416 
+L 169.923705 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_81">
+    <path d="M 182.440913 32.234416 
+L 182.440913 44.751624 
+L 169.923705 44.751624 
+L 169.923705 32.234416 
+L 182.440913 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_82">
+    <path d="M 182.440913 32.234416 
+L 182.440913 44.751624 
+L 169.923705 44.751624 
+L 169.923705 32.234416 
+L 182.440913 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_83">
+    <path d="M 194.958122 32.234416 
+L 194.958122 44.751624 
+L 182.440913 44.751624 
+L 182.440913 32.234416 
+L 194.958122 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_84">
+    <path d="M 194.958122 32.234416 
+L 194.958122 44.751624 
+L 182.440913 44.751624 
+L 182.440913 32.234416 
+L 194.958122 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_85">
+    <path d="M 207.47533 32.234416 
+L 207.47533 44.751624 
+L 194.958122 44.751624 
+L 194.958122 32.234416 
+L 207.47533 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_86">
+    <path d="M 207.47533 32.234416 
+L 207.47533 44.751624 
+L 194.958122 44.751624 
+L 194.958122 32.234416 
+L 207.47533 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_87">
+    <path d="M 219.992538 32.234416 
+L 219.992538 44.751624 
+L 207.47533 44.751624 
+L 207.47533 32.234416 
+L 219.992538 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_88">
+    <path d="M 219.992538 32.234416 
+L 219.992538 44.751624 
+L 207.47533 44.751624 
+L 207.47533 32.234416 
+L 219.992538 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_89">
+    <path d="M 232.509746 32.234416 
+L 232.509746 44.751624 
+L 219.992538 44.751624 
+L 219.992538 32.234416 
+L 232.509746 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_90">
+    <path d="M 232.509746 32.234416 
+L 232.509746 44.751624 
+L 219.992538 44.751624 
+L 219.992538 32.234416 
+L 232.509746 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_91">
+    <path d="M 245.026954 32.234416 
+L 245.026954 44.751624 
+L 232.509746 44.751624 
+L 232.509746 32.234416 
+L 245.026954 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_92">
+    <path d="M 245.026954 32.234416 
+L 245.026954 44.751624 
+L 232.509746 44.751624 
+L 232.509746 32.234416 
+L 245.026954 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_93">
+    <path d="M 257.544162 32.234416 
+L 257.544162 44.751624 
+L 245.026954 44.751624 
+L 245.026954 32.234416 
+L 257.544162 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_94">
+    <path d="M 257.544162 32.234416 
+L 257.544162 44.751624 
+L 245.026954 44.751624 
+L 245.026954 32.234416 
+L 257.544162 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_95">
+    <path d="M 270.06137 32.234416 
+L 270.06137 44.751624 
+L 257.544162 44.751624 
+L 257.544162 32.234416 
+L 270.06137 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_96">
+    <path d="M 270.06137 32.234416 
+L 270.06137 44.751624 
+L 257.544162 44.751624 
+L 257.544162 32.234416 
+L 270.06137 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_97">
+    <path d="M 282.578578 32.234416 
+L 282.578578 44.751624 
+L 270.06137 44.751624 
+L 270.06137 32.234416 
+L 282.578578 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_98">
+    <path d="M 282.578578 32.234416 
+L 282.578578 44.751624 
+L 270.06137 44.751624 
+L 270.06137 32.234416 
+L 282.578578 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_99">
+    <path d="M 295.095786 32.234416 
+L 295.095786 44.751624 
+L 282.578578 44.751624 
+L 282.578578 32.234416 
+L 295.095786 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_100">
+    <path d="M 295.095786 32.234416 
+L 295.095786 44.751624 
+L 282.578578 44.751624 
+L 282.578578 32.234416 
+L 295.095786 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_101">
+    <path d="M 307.612994 32.234416 
+L 307.612994 44.751624 
+L 295.095786 44.751624 
+L 295.095786 32.234416 
+L 307.612994 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_102">
+    <path d="M 307.612994 32.234416 
+L 307.612994 44.751624 
+L 295.095786 44.751624 
+L 295.095786 32.234416 
+L 307.612994 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_103">
+    <path d="M 320.130203 32.234416 
+L 320.130203 44.751624 
+L 307.612994 44.751624 
+L 307.612994 32.234416 
+L 320.130203 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_104">
+    <path d="M 320.130203 32.234416 
+L 320.130203 44.751624 
+L 307.612994 44.751624 
+L 307.612994 32.234416 
+L 320.130203 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_105">
+    <path d="M 332.647411 32.234416 
+L 332.647411 44.751624 
+L 320.130203 44.751624 
+L 320.130203 32.234416 
+L 332.647411 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_106">
+    <path d="M 332.647411 32.234416 
+L 332.647411 44.751624 
+L 320.130203 44.751624 
+L 320.130203 32.234416 
+L 332.647411 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_107">
+    <path d="M 345.164619 32.234416 
+L 345.164619 44.751624 
+L 332.647411 44.751624 
+L 332.647411 32.234416 
+L 345.164619 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_108">
+    <path d="M 345.164619 32.234416 
+L 345.164619 44.751624 
+L 332.647411 44.751624 
+L 332.647411 32.234416 
+L 345.164619 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_109">
+    <path d="M 357.681827 32.234416 
+L 357.681827 44.751624 
+L 345.164619 44.751624 
+L 345.164619 32.234416 
+L 357.681827 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_110">
+    <path d="M 357.681827 32.234416 
+L 357.681827 44.751624 
+L 345.164619 44.751624 
+L 345.164619 32.234416 
+L 357.681827 32.234416 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_111">
+    <path d="M 32.234416 44.751624 
+L 32.234416 57.268832 
+L 19.717208 57.268832 
+L 19.717208 44.751624 
+L 32.234416 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_112">
+    <path d="M 32.234416 44.751624 
+L 32.234416 57.268832 
+L 19.717208 57.268832 
+L 19.717208 44.751624 
+L 32.234416 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_113">
+    <path d="M 44.751624 44.751624 
+L 44.751624 57.268832 
+L 32.234416 57.268832 
+L 32.234416 44.751624 
+L 44.751624 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_114">
+    <path d="M 44.751624 44.751624 
+L 44.751624 57.268832 
+L 32.234416 57.268832 
+L 32.234416 44.751624 
+L 44.751624 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_115">
+    <path d="M 57.268832 44.751624 
+L 57.268832 57.268832 
+L 44.751624 57.268832 
+L 44.751624 44.751624 
+L 57.268832 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_116">
+    <path d="M 57.268832 44.751624 
+L 57.268832 57.268832 
+L 44.751624 57.268832 
+L 44.751624 44.751624 
+L 57.268832 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_117">
+    <path d="M 69.786041 44.751624 
+L 69.786041 57.268832 
+L 57.268832 57.268832 
+L 57.268832 44.751624 
+L 69.786041 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_118">
+    <path d="M 69.786041 44.751624 
+L 69.786041 57.268832 
+L 57.268832 57.268832 
+L 57.268832 44.751624 
+L 69.786041 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_119">
+    <path d="M 82.303249 44.751624 
+L 82.303249 57.268832 
+L 69.786041 57.268832 
+L 69.786041 44.751624 
+L 82.303249 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_120">
+    <path d="M 82.303249 44.751624 
+L 82.303249 57.268832 
+L 69.786041 57.268832 
+L 69.786041 44.751624 
+L 82.303249 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_121">
+    <path d="M 94.820457 44.751624 
+L 94.820457 57.268832 
+L 82.303249 57.268832 
+L 82.303249 44.751624 
+L 94.820457 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_122">
+    <path d="M 94.820457 44.751624 
+L 94.820457 57.268832 
+L 82.303249 57.268832 
+L 82.303249 44.751624 
+L 94.820457 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_123">
+    <path d="M 107.337665 44.751624 
+L 107.337665 57.268832 
+L 94.820457 57.268832 
+L 94.820457 44.751624 
+L 107.337665 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_124">
+    <path d="M 107.337665 44.751624 
+L 107.337665 57.268832 
+L 94.820457 57.268832 
+L 94.820457 44.751624 
+L 107.337665 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_125">
+    <path d="M 119.854873 44.751624 
+L 119.854873 57.268832 
+L 107.337665 57.268832 
+L 107.337665 44.751624 
+L 119.854873 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_126">
+    <path d="M 119.854873 44.751624 
+L 119.854873 57.268832 
+L 107.337665 57.268832 
+L 107.337665 44.751624 
+L 119.854873 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_127">
+    <path d="M 132.372081 44.751624 
+L 132.372081 57.268832 
+L 119.854873 57.268832 
+L 119.854873 44.751624 
+L 132.372081 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_128">
+    <path d="M 132.372081 44.751624 
+L 132.372081 57.268832 
+L 119.854873 57.268832 
+L 119.854873 44.751624 
+L 132.372081 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_129">
+    <path d="M 144.889289 44.751624 
+L 144.889289 57.268832 
+L 132.372081 57.268832 
+L 132.372081 44.751624 
+L 144.889289 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_130">
+    <path d="M 144.889289 44.751624 
+L 144.889289 57.268832 
+L 132.372081 57.268832 
+L 132.372081 44.751624 
+L 144.889289 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_131">
+    <path d="M 157.406497 44.751624 
+L 157.406497 57.268832 
+L 144.889289 57.268832 
+L 144.889289 44.751624 
+L 157.406497 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_132">
+    <path d="M 157.406497 44.751624 
+L 157.406497 57.268832 
+L 144.889289 57.268832 
+L 144.889289 44.751624 
+L 157.406497 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_133">
+    <path d="M 169.923705 44.751624 
+L 169.923705 57.268832 
+L 157.406497 57.268832 
+L 157.406497 44.751624 
+L 169.923705 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_134">
+    <path d="M 169.923705 44.751624 
+L 169.923705 57.268832 
+L 157.406497 57.268832 
+L 157.406497 44.751624 
+L 169.923705 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_135">
+    <path d="M 182.440913 44.751624 
+L 182.440913 57.268832 
+L 169.923705 57.268832 
+L 169.923705 44.751624 
+L 182.440913 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_136">
+    <path d="M 182.440913 44.751624 
+L 182.440913 57.268832 
+L 169.923705 57.268832 
+L 169.923705 44.751624 
+L 182.440913 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_137">
+    <path d="M 194.958122 44.751624 
+L 194.958122 57.268832 
+L 182.440913 57.268832 
+L 182.440913 44.751624 
+L 194.958122 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_138">
+    <path d="M 194.958122 44.751624 
+L 194.958122 57.268832 
+L 182.440913 57.268832 
+L 182.440913 44.751624 
+L 194.958122 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_139">
+    <path d="M 207.47533 44.751624 
+L 207.47533 57.268832 
+L 194.958122 57.268832 
+L 194.958122 44.751624 
+L 207.47533 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_140">
+    <path d="M 207.47533 44.751624 
+L 207.47533 57.268832 
+L 194.958122 57.268832 
+L 194.958122 44.751624 
+L 207.47533 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_141">
+    <path d="M 219.992538 44.751624 
+L 219.992538 57.268832 
+L 207.47533 57.268832 
+L 207.47533 44.751624 
+L 219.992538 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_142">
+    <path d="M 219.992538 44.751624 
+L 219.992538 57.268832 
+L 207.47533 57.268832 
+L 207.47533 44.751624 
+L 219.992538 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_143">
+    <path d="M 232.509746 44.751624 
+L 232.509746 57.268832 
+L 219.992538 57.268832 
+L 219.992538 44.751624 
+L 232.509746 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_144">
+    <path d="M 232.509746 44.751624 
+L 232.509746 57.268832 
+L 219.992538 57.268832 
+L 219.992538 44.751624 
+L 232.509746 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_145">
+    <path d="M 245.026954 44.751624 
+L 245.026954 57.268832 
+L 232.509746 57.268832 
+L 232.509746 44.751624 
+L 245.026954 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_146">
+    <path d="M 245.026954 44.751624 
+L 245.026954 57.268832 
+L 232.509746 57.268832 
+L 232.509746 44.751624 
+L 245.026954 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_147">
+    <path d="M 257.544162 44.751624 
+L 257.544162 57.268832 
+L 245.026954 57.268832 
+L 245.026954 44.751624 
+L 257.544162 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_148">
+    <path d="M 257.544162 44.751624 
+L 257.544162 57.268832 
+L 245.026954 57.268832 
+L 245.026954 44.751624 
+L 257.544162 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_149">
+    <path d="M 270.06137 44.751624 
+L 270.06137 57.268832 
+L 257.544162 57.268832 
+L 257.544162 44.751624 
+L 270.06137 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_150">
+    <path d="M 270.06137 44.751624 
+L 270.06137 57.268832 
+L 257.544162 57.268832 
+L 257.544162 44.751624 
+L 270.06137 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_151">
+    <path d="M 282.578578 44.751624 
+L 282.578578 57.268832 
+L 270.06137 57.268832 
+L 270.06137 44.751624 
+L 282.578578 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_152">
+    <path d="M 282.578578 44.751624 
+L 282.578578 57.268832 
+L 270.06137 57.268832 
+L 270.06137 44.751624 
+L 282.578578 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_153">
+    <path d="M 295.095786 44.751624 
+L 295.095786 57.268832 
+L 282.578578 57.268832 
+L 282.578578 44.751624 
+L 295.095786 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_154">
+    <path d="M 295.095786 44.751624 
+L 295.095786 57.268832 
+L 282.578578 57.268832 
+L 282.578578 44.751624 
+L 295.095786 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_155">
+    <path d="M 307.612994 44.751624 
+L 307.612994 57.268832 
+L 295.095786 57.268832 
+L 295.095786 44.751624 
+L 307.612994 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_156">
+    <path d="M 307.612994 44.751624 
+L 307.612994 57.268832 
+L 295.095786 57.268832 
+L 295.095786 44.751624 
+L 307.612994 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_157">
+    <path d="M 320.130203 44.751624 
+L 320.130203 57.268832 
+L 307.612994 57.268832 
+L 307.612994 44.751624 
+L 320.130203 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_158">
+    <path d="M 320.130203 44.751624 
+L 320.130203 57.268832 
+L 307.612994 57.268832 
+L 307.612994 44.751624 
+L 320.130203 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_159">
+    <path d="M 332.647411 44.751624 
+L 332.647411 57.268832 
+L 320.130203 57.268832 
+L 320.130203 44.751624 
+L 332.647411 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_160">
+    <path d="M 332.647411 44.751624 
+L 332.647411 57.268832 
+L 320.130203 57.268832 
+L 320.130203 44.751624 
+L 332.647411 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_161">
+    <path d="M 345.164619 44.751624 
+L 345.164619 57.268832 
+L 332.647411 57.268832 
+L 332.647411 44.751624 
+L 345.164619 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_162">
+    <path d="M 345.164619 44.751624 
+L 345.164619 57.268832 
+L 332.647411 57.268832 
+L 332.647411 44.751624 
+L 345.164619 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_163">
+    <path d="M 357.681827 44.751624 
+L 357.681827 57.268832 
+L 345.164619 57.268832 
+L 345.164619 44.751624 
+L 357.681827 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_164">
+    <path d="M 357.681827 44.751624 
+L 357.681827 57.268832 
+L 345.164619 57.268832 
+L 345.164619 44.751624 
+L 357.681827 44.751624 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_165">
+    <path d="M 32.234416 57.268832 
+L 32.234416 69.786041 
+L 19.717208 69.786041 
+L 19.717208 57.268832 
+L 32.234416 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_166">
+    <path d="M 32.234416 57.268832 
+L 32.234416 69.786041 
+L 19.717208 69.786041 
+L 19.717208 57.268832 
+L 32.234416 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_167">
+    <path d="M 44.751624 57.268832 
+L 44.751624 69.786041 
+L 32.234416 69.786041 
+L 32.234416 57.268832 
+L 44.751624 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_168">
+    <path d="M 44.751624 57.268832 
+L 44.751624 69.786041 
+L 32.234416 69.786041 
+L 32.234416 57.268832 
+L 44.751624 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_169">
+    <path d="M 57.268832 57.268832 
+L 57.268832 69.786041 
+L 44.751624 69.786041 
+L 44.751624 57.268832 
+L 57.268832 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_170">
+    <path d="M 57.268832 57.268832 
+L 57.268832 69.786041 
+L 44.751624 69.786041 
+L 44.751624 57.268832 
+L 57.268832 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_171">
+    <path d="M 69.786041 57.268832 
+L 69.786041 69.786041 
+L 57.268832 69.786041 
+L 57.268832 57.268832 
+L 69.786041 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_172">
+    <path d="M 69.786041 57.268832 
+L 69.786041 69.786041 
+L 57.268832 69.786041 
+L 57.268832 57.268832 
+L 69.786041 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_173">
+    <path d="M 82.303249 57.268832 
+L 82.303249 69.786041 
+L 69.786041 69.786041 
+L 69.786041 57.268832 
+L 82.303249 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_174">
+    <path d="M 82.303249 57.268832 
+L 82.303249 69.786041 
+L 69.786041 69.786041 
+L 69.786041 57.268832 
+L 82.303249 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_175">
+    <path d="M 94.820457 57.268832 
+L 94.820457 69.786041 
+L 82.303249 69.786041 
+L 82.303249 57.268832 
+L 94.820457 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_176">
+    <path d="M 94.820457 57.268832 
+L 94.820457 69.786041 
+L 82.303249 69.786041 
+L 82.303249 57.268832 
+L 94.820457 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_177">
+    <path d="M 107.337665 57.268832 
+L 107.337665 69.786041 
+L 94.820457 69.786041 
+L 94.820457 57.268832 
+L 107.337665 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_178">
+    <path d="M 107.337665 57.268832 
+L 107.337665 69.786041 
+L 94.820457 69.786041 
+L 94.820457 57.268832 
+L 107.337665 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_179">
+    <path d="M 119.854873 57.268832 
+L 119.854873 69.786041 
+L 107.337665 69.786041 
+L 107.337665 57.268832 
+L 119.854873 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_180">
+    <path d="M 119.854873 57.268832 
+L 119.854873 69.786041 
+L 107.337665 69.786041 
+L 107.337665 57.268832 
+L 119.854873 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_181">
+    <path d="M 132.372081 57.268832 
+L 132.372081 69.786041 
+L 119.854873 69.786041 
+L 119.854873 57.268832 
+L 132.372081 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_182">
+    <path d="M 132.372081 57.268832 
+L 132.372081 69.786041 
+L 119.854873 69.786041 
+L 119.854873 57.268832 
+L 132.372081 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_183">
+    <path d="M 144.889289 57.268832 
+L 144.889289 69.786041 
+L 132.372081 69.786041 
+L 132.372081 57.268832 
+L 144.889289 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_184">
+    <path d="M 144.889289 57.268832 
+L 144.889289 69.786041 
+L 132.372081 69.786041 
+L 132.372081 57.268832 
+L 144.889289 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_185">
+    <path d="M 157.406497 57.268832 
+L 157.406497 69.786041 
+L 144.889289 69.786041 
+L 144.889289 57.268832 
+L 157.406497 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_186">
+    <path d="M 157.406497 57.268832 
+L 157.406497 69.786041 
+L 144.889289 69.786041 
+L 144.889289 57.268832 
+L 157.406497 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_187">
+    <path d="M 169.923705 57.268832 
+L 169.923705 69.786041 
+L 157.406497 69.786041 
+L 157.406497 57.268832 
+L 169.923705 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_188">
+    <path d="M 169.923705 57.268832 
+L 169.923705 69.786041 
+L 157.406497 69.786041 
+L 157.406497 57.268832 
+L 169.923705 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_189">
+    <path d="M 182.440913 57.268832 
+L 182.440913 69.786041 
+L 169.923705 69.786041 
+L 169.923705 57.268832 
+L 182.440913 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_190">
+    <path d="M 182.440913 57.268832 
+L 182.440913 69.786041 
+L 169.923705 69.786041 
+L 169.923705 57.268832 
+L 182.440913 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_191">
+    <path d="M 194.958122 57.268832 
+L 194.958122 69.786041 
+L 182.440913 69.786041 
+L 182.440913 57.268832 
+L 194.958122 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_192">
+    <path d="M 194.958122 57.268832 
+L 194.958122 69.786041 
+L 182.440913 69.786041 
+L 182.440913 57.268832 
+L 194.958122 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_193">
+    <path d="M 207.47533 57.268832 
+L 207.47533 69.786041 
+L 194.958122 69.786041 
+L 194.958122 57.268832 
+L 207.47533 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_194">
+    <path d="M 207.47533 57.268832 
+L 207.47533 69.786041 
+L 194.958122 69.786041 
+L 194.958122 57.268832 
+L 207.47533 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_195">
+    <path d="M 219.992538 57.268832 
+L 219.992538 69.786041 
+L 207.47533 69.786041 
+L 207.47533 57.268832 
+L 219.992538 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_196">
+    <path d="M 219.992538 57.268832 
+L 219.992538 69.786041 
+L 207.47533 69.786041 
+L 207.47533 57.268832 
+L 219.992538 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_197">
+    <path d="M 232.509746 57.268832 
+L 232.509746 69.786041 
+L 219.992538 69.786041 
+L 219.992538 57.268832 
+L 232.509746 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_198">
+    <path d="M 232.509746 57.268832 
+L 232.509746 69.786041 
+L 219.992538 69.786041 
+L 219.992538 57.268832 
+L 232.509746 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_199">
+    <path d="M 245.026954 57.268832 
+L 245.026954 69.786041 
+L 232.509746 69.786041 
+L 232.509746 57.268832 
+L 245.026954 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_200">
+    <path d="M 245.026954 57.268832 
+L 245.026954 69.786041 
+L 232.509746 69.786041 
+L 232.509746 57.268832 
+L 245.026954 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_201">
+    <path d="M 257.544162 57.268832 
+L 257.544162 69.786041 
+L 245.026954 69.786041 
+L 245.026954 57.268832 
+L 257.544162 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_202">
+    <path d="M 257.544162 57.268832 
+L 257.544162 69.786041 
+L 245.026954 69.786041 
+L 245.026954 57.268832 
+L 257.544162 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_203">
+    <path d="M 270.06137 57.268832 
+L 270.06137 69.786041 
+L 257.544162 69.786041 
+L 257.544162 57.268832 
+L 270.06137 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_204">
+    <path d="M 270.06137 57.268832 
+L 270.06137 69.786041 
+L 257.544162 69.786041 
+L 257.544162 57.268832 
+L 270.06137 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_205">
+    <path d="M 282.578578 57.268832 
+L 282.578578 69.786041 
+L 270.06137 69.786041 
+L 270.06137 57.268832 
+L 282.578578 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_206">
+    <path d="M 282.578578 57.268832 
+L 282.578578 69.786041 
+L 270.06137 69.786041 
+L 270.06137 57.268832 
+L 282.578578 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_207">
+    <path d="M 295.095786 57.268832 
+L 295.095786 69.786041 
+L 282.578578 69.786041 
+L 282.578578 57.268832 
+L 295.095786 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_208">
+    <path d="M 295.095786 57.268832 
+L 295.095786 69.786041 
+L 282.578578 69.786041 
+L 282.578578 57.268832 
+L 295.095786 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_209">
+    <path d="M 307.612994 57.268832 
+L 307.612994 69.786041 
+L 295.095786 69.786041 
+L 295.095786 57.268832 
+L 307.612994 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_210">
+    <path d="M 307.612994 57.268832 
+L 307.612994 69.786041 
+L 295.095786 69.786041 
+L 295.095786 57.268832 
+L 307.612994 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_211">
+    <path d="M 320.130203 57.268832 
+L 320.130203 69.786041 
+L 307.612994 69.786041 
+L 307.612994 57.268832 
+L 320.130203 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_212">
+    <path d="M 320.130203 57.268832 
+L 320.130203 69.786041 
+L 307.612994 69.786041 
+L 307.612994 57.268832 
+L 320.130203 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_213">
+    <path d="M 332.647411 57.268832 
+L 332.647411 69.786041 
+L 320.130203 69.786041 
+L 320.130203 57.268832 
+L 332.647411 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_214">
+    <path d="M 332.647411 57.268832 
+L 332.647411 69.786041 
+L 320.130203 69.786041 
+L 320.130203 57.268832 
+L 332.647411 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_215">
+    <path d="M 345.164619 57.268832 
+L 345.164619 69.786041 
+L 332.647411 69.786041 
+L 332.647411 57.268832 
+L 345.164619 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_216">
+    <path d="M 345.164619 57.268832 
+L 345.164619 69.786041 
+L 332.647411 69.786041 
+L 332.647411 57.268832 
+L 345.164619 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_217">
+    <path d="M 357.681827 57.268832 
+L 357.681827 69.786041 
+L 345.164619 69.786041 
+L 345.164619 57.268832 
+L 357.681827 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_218">
+    <path d="M 357.681827 57.268832 
+L 357.681827 69.786041 
+L 345.164619 69.786041 
+L 345.164619 57.268832 
+L 357.681827 57.268832 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_219">
+    <path d="M 32.234416 69.786041 
+L 32.234416 82.303249 
+L 19.717208 82.303249 
+L 19.717208 69.786041 
+L 32.234416 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_220">
+    <path d="M 32.234416 69.786041 
+L 32.234416 82.303249 
+L 19.717208 82.303249 
+L 19.717208 69.786041 
+L 32.234416 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_221">
+    <path d="M 44.751624 69.786041 
+L 44.751624 82.303249 
+L 32.234416 82.303249 
+L 32.234416 69.786041 
+L 44.751624 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_222">
+    <path d="M 44.751624 69.786041 
+L 44.751624 82.303249 
+L 32.234416 82.303249 
+L 32.234416 69.786041 
+L 44.751624 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_223">
+    <path d="M 57.268832 69.786041 
+L 57.268832 82.303249 
+L 44.751624 82.303249 
+L 44.751624 69.786041 
+L 57.268832 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_224">
+    <path d="M 57.268832 69.786041 
+L 57.268832 82.303249 
+L 44.751624 82.303249 
+L 44.751624 69.786041 
+L 57.268832 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_225">
+    <path d="M 69.786041 69.786041 
+L 69.786041 82.303249 
+L 57.268832 82.303249 
+L 57.268832 69.786041 
+L 69.786041 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_226">
+    <path d="M 69.786041 69.786041 
+L 69.786041 82.303249 
+L 57.268832 82.303249 
+L 57.268832 69.786041 
+L 69.786041 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_227">
+    <path d="M 82.303249 69.786041 
+L 82.303249 82.303249 
+L 69.786041 82.303249 
+L 69.786041 69.786041 
+L 82.303249 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_228">
+    <path d="M 82.303249 69.786041 
+L 82.303249 82.303249 
+L 69.786041 82.303249 
+L 69.786041 69.786041 
+L 82.303249 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_229">
+    <path d="M 94.820457 69.786041 
+L 94.820457 82.303249 
+L 82.303249 82.303249 
+L 82.303249 69.786041 
+L 94.820457 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_230">
+    <path d="M 94.820457 69.786041 
+L 94.820457 82.303249 
+L 82.303249 82.303249 
+L 82.303249 69.786041 
+L 94.820457 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_231">
+    <path d="M 107.337665 69.786041 
+L 107.337665 82.303249 
+L 94.820457 82.303249 
+L 94.820457 69.786041 
+L 107.337665 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_232">
+    <path d="M 107.337665 69.786041 
+L 107.337665 82.303249 
+L 94.820457 82.303249 
+L 94.820457 69.786041 
+L 107.337665 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_233">
+    <path d="M 119.854873 69.786041 
+L 119.854873 82.303249 
+L 107.337665 82.303249 
+L 107.337665 69.786041 
+L 119.854873 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_234">
+    <path d="M 119.854873 69.786041 
+L 119.854873 82.303249 
+L 107.337665 82.303249 
+L 107.337665 69.786041 
+L 119.854873 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_235">
+    <path d="M 132.372081 69.786041 
+L 132.372081 82.303249 
+L 119.854873 82.303249 
+L 119.854873 69.786041 
+L 132.372081 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_236">
+    <path d="M 132.372081 69.786041 
+L 132.372081 82.303249 
+L 119.854873 82.303249 
+L 119.854873 69.786041 
+L 132.372081 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_237">
+    <path d="M 144.889289 69.786041 
+L 144.889289 82.303249 
+L 132.372081 82.303249 
+L 132.372081 69.786041 
+L 144.889289 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_238">
+    <path d="M 144.889289 69.786041 
+L 144.889289 82.303249 
+L 132.372081 82.303249 
+L 132.372081 69.786041 
+L 144.889289 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_239">
+    <path d="M 157.406497 69.786041 
+L 157.406497 82.303249 
+L 144.889289 82.303249 
+L 144.889289 69.786041 
+L 157.406497 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_240">
+    <path d="M 157.406497 69.786041 
+L 157.406497 82.303249 
+L 144.889289 82.303249 
+L 144.889289 69.786041 
+L 157.406497 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_241">
+    <path d="M 169.923705 69.786041 
+L 169.923705 82.303249 
+L 157.406497 82.303249 
+L 157.406497 69.786041 
+L 169.923705 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_242">
+    <path d="M 169.923705 69.786041 
+L 169.923705 82.303249 
+L 157.406497 82.303249 
+L 157.406497 69.786041 
+L 169.923705 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_243">
+    <path d="M 182.440913 69.786041 
+L 182.440913 82.303249 
+L 169.923705 82.303249 
+L 169.923705 69.786041 
+L 182.440913 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_244">
+    <path d="M 182.440913 69.786041 
+L 182.440913 82.303249 
+L 169.923705 82.303249 
+L 169.923705 69.786041 
+L 182.440913 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_245">
+    <path d="M 194.958122 69.786041 
+L 194.958122 82.303249 
+L 182.440913 82.303249 
+L 182.440913 69.786041 
+L 194.958122 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_246">
+    <path d="M 194.958122 69.786041 
+L 194.958122 82.303249 
+L 182.440913 82.303249 
+L 182.440913 69.786041 
+L 194.958122 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_247">
+    <path d="M 207.47533 69.786041 
+L 207.47533 82.303249 
+L 194.958122 82.303249 
+L 194.958122 69.786041 
+L 207.47533 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_248">
+    <path d="M 207.47533 69.786041 
+L 207.47533 82.303249 
+L 194.958122 82.303249 
+L 194.958122 69.786041 
+L 207.47533 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_249">
+    <path d="M 219.992538 69.786041 
+L 219.992538 82.303249 
+L 207.47533 82.303249 
+L 207.47533 69.786041 
+L 219.992538 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_250">
+    <path d="M 219.992538 69.786041 
+L 219.992538 82.303249 
+L 207.47533 82.303249 
+L 207.47533 69.786041 
+L 219.992538 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_251">
+    <path d="M 232.509746 69.786041 
+L 232.509746 82.303249 
+L 219.992538 82.303249 
+L 219.992538 69.786041 
+L 232.509746 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_252">
+    <path d="M 232.509746 69.786041 
+L 232.509746 82.303249 
+L 219.992538 82.303249 
+L 219.992538 69.786041 
+L 232.509746 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_253">
+    <path d="M 245.026954 69.786041 
+L 245.026954 82.303249 
+L 232.509746 82.303249 
+L 232.509746 69.786041 
+L 245.026954 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_254">
+    <path d="M 245.026954 69.786041 
+L 245.026954 82.303249 
+L 232.509746 82.303249 
+L 232.509746 69.786041 
+L 245.026954 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_255">
+    <path d="M 257.544162 69.786041 
+L 257.544162 82.303249 
+L 245.026954 82.303249 
+L 245.026954 69.786041 
+L 257.544162 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_256">
+    <path d="M 257.544162 69.786041 
+L 257.544162 82.303249 
+L 245.026954 82.303249 
+L 245.026954 69.786041 
+L 257.544162 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_257">
+    <path d="M 270.06137 69.786041 
+L 270.06137 82.303249 
+L 257.544162 82.303249 
+L 257.544162 69.786041 
+L 270.06137 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_258">
+    <path d="M 270.06137 69.786041 
+L 270.06137 82.303249 
+L 257.544162 82.303249 
+L 257.544162 69.786041 
+L 270.06137 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_259">
+    <path d="M 282.578578 69.786041 
+L 282.578578 82.303249 
+L 270.06137 82.303249 
+L 270.06137 69.786041 
+L 282.578578 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_260">
+    <path d="M 282.578578 69.786041 
+L 282.578578 82.303249 
+L 270.06137 82.303249 
+L 270.06137 69.786041 
+L 282.578578 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_261">
+    <path d="M 295.095786 69.786041 
+L 295.095786 82.303249 
+L 282.578578 82.303249 
+L 282.578578 69.786041 
+L 295.095786 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_262">
+    <path d="M 295.095786 69.786041 
+L 295.095786 82.303249 
+L 282.578578 82.303249 
+L 282.578578 69.786041 
+L 295.095786 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_263">
+    <path d="M 307.612994 69.786041 
+L 307.612994 82.303249 
+L 295.095786 82.303249 
+L 295.095786 69.786041 
+L 307.612994 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_264">
+    <path d="M 307.612994 69.786041 
+L 307.612994 82.303249 
+L 295.095786 82.303249 
+L 295.095786 69.786041 
+L 307.612994 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_265">
+    <path d="M 320.130203 69.786041 
+L 320.130203 82.303249 
+L 307.612994 82.303249 
+L 307.612994 69.786041 
+L 320.130203 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_266">
+    <path d="M 320.130203 69.786041 
+L 320.130203 82.303249 
+L 307.612994 82.303249 
+L 307.612994 69.786041 
+L 320.130203 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_267">
+    <path d="M 332.647411 69.786041 
+L 332.647411 82.303249 
+L 320.130203 82.303249 
+L 320.130203 69.786041 
+L 332.647411 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_268">
+    <path d="M 332.647411 69.786041 
+L 332.647411 82.303249 
+L 320.130203 82.303249 
+L 320.130203 69.786041 
+L 332.647411 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_269">
+    <path d="M 345.164619 69.786041 
+L 345.164619 82.303249 
+L 332.647411 82.303249 
+L 332.647411 69.786041 
+L 345.164619 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_270">
+    <path d="M 345.164619 69.786041 
+L 345.164619 82.303249 
+L 332.647411 82.303249 
+L 332.647411 69.786041 
+L 345.164619 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_271">
+    <path d="M 357.681827 69.786041 
+L 357.681827 82.303249 
+L 345.164619 82.303249 
+L 345.164619 69.786041 
+L 357.681827 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_272">
+    <path d="M 357.681827 69.786041 
+L 357.681827 82.303249 
+L 345.164619 82.303249 
+L 345.164619 69.786041 
+L 357.681827 69.786041 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_273">
+    <path d="M 32.234416 82.303249 
+L 32.234416 94.820457 
+L 19.717208 94.820457 
+L 19.717208 82.303249 
+L 32.234416 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_274">
+    <path d="M 32.234416 82.303249 
+L 32.234416 94.820457 
+L 19.717208 94.820457 
+L 19.717208 82.303249 
+L 32.234416 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_275">
+    <path d="M 44.751624 82.303249 
+L 44.751624 94.820457 
+L 32.234416 94.820457 
+L 32.234416 82.303249 
+L 44.751624 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_276">
+    <path d="M 44.751624 82.303249 
+L 44.751624 94.820457 
+L 32.234416 94.820457 
+L 32.234416 82.303249 
+L 44.751624 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_277">
+    <path d="M 57.268832 82.303249 
+L 57.268832 94.820457 
+L 44.751624 94.820457 
+L 44.751624 82.303249 
+L 57.268832 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_278">
+    <path d="M 57.268832 82.303249 
+L 57.268832 94.820457 
+L 44.751624 94.820457 
+L 44.751624 82.303249 
+L 57.268832 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_279">
+    <path d="M 69.786041 82.303249 
+L 69.786041 94.820457 
+L 57.268832 94.820457 
+L 57.268832 82.303249 
+L 69.786041 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_280">
+    <path d="M 69.786041 82.303249 
+L 69.786041 94.820457 
+L 57.268832 94.820457 
+L 57.268832 82.303249 
+L 69.786041 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_281">
+    <path d="M 82.303249 82.303249 
+L 82.303249 94.820457 
+L 69.786041 94.820457 
+L 69.786041 82.303249 
+L 82.303249 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_282">
+    <path d="M 82.303249 82.303249 
+L 82.303249 94.820457 
+L 69.786041 94.820457 
+L 69.786041 82.303249 
+L 82.303249 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_283">
+    <path d="M 94.820457 82.303249 
+L 94.820457 94.820457 
+L 82.303249 94.820457 
+L 82.303249 82.303249 
+L 94.820457 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_284">
+    <path d="M 94.820457 82.303249 
+L 94.820457 94.820457 
+L 82.303249 94.820457 
+L 82.303249 82.303249 
+L 94.820457 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_285">
+    <path d="M 107.337665 82.303249 
+L 107.337665 94.820457 
+L 94.820457 94.820457 
+L 94.820457 82.303249 
+L 107.337665 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_286">
+    <path d="M 107.337665 82.303249 
+L 107.337665 94.820457 
+L 94.820457 94.820457 
+L 94.820457 82.303249 
+L 107.337665 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_287">
+    <path d="M 119.854873 82.303249 
+L 119.854873 94.820457 
+L 107.337665 94.820457 
+L 107.337665 82.303249 
+L 119.854873 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_288">
+    <path d="M 119.854873 82.303249 
+L 119.854873 94.820457 
+L 107.337665 94.820457 
+L 107.337665 82.303249 
+L 119.854873 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_289">
+    <path d="M 132.372081 82.303249 
+L 132.372081 94.820457 
+L 119.854873 94.820457 
+L 119.854873 82.303249 
+L 132.372081 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_290">
+    <path d="M 132.372081 82.303249 
+L 132.372081 94.820457 
+L 119.854873 94.820457 
+L 119.854873 82.303249 
+L 132.372081 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_291">
+    <path d="M 144.889289 82.303249 
+L 144.889289 94.820457 
+L 132.372081 94.820457 
+L 132.372081 82.303249 
+L 144.889289 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_292">
+    <path d="M 144.889289 82.303249 
+L 144.889289 94.820457 
+L 132.372081 94.820457 
+L 132.372081 82.303249 
+L 144.889289 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_293">
+    <path d="M 157.406497 82.303249 
+L 157.406497 94.820457 
+L 144.889289 94.820457 
+L 144.889289 82.303249 
+L 157.406497 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_294">
+    <path d="M 157.406497 82.303249 
+L 157.406497 94.820457 
+L 144.889289 94.820457 
+L 144.889289 82.303249 
+L 157.406497 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_295">
+    <path d="M 169.923705 82.303249 
+L 169.923705 94.820457 
+L 157.406497 94.820457 
+L 157.406497 82.303249 
+L 169.923705 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_296">
+    <path d="M 169.923705 82.303249 
+L 169.923705 94.820457 
+L 157.406497 94.820457 
+L 157.406497 82.303249 
+L 169.923705 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_297">
+    <path d="M 182.440913 82.303249 
+L 182.440913 94.820457 
+L 169.923705 94.820457 
+L 169.923705 82.303249 
+L 182.440913 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_298">
+    <path d="M 182.440913 82.303249 
+L 182.440913 94.820457 
+L 169.923705 94.820457 
+L 169.923705 82.303249 
+L 182.440913 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_299">
+    <path d="M 194.958122 82.303249 
+L 194.958122 94.820457 
+L 182.440913 94.820457 
+L 182.440913 82.303249 
+L 194.958122 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_300">
+    <path d="M 194.958122 82.303249 
+L 194.958122 94.820457 
+L 182.440913 94.820457 
+L 182.440913 82.303249 
+L 194.958122 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_301">
+    <path d="M 207.47533 82.303249 
+L 207.47533 94.820457 
+L 194.958122 94.820457 
+L 194.958122 82.303249 
+L 207.47533 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_302">
+    <path d="M 207.47533 82.303249 
+L 207.47533 94.820457 
+L 194.958122 94.820457 
+L 194.958122 82.303249 
+L 207.47533 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_303">
+    <path d="M 219.992538 82.303249 
+L 219.992538 94.820457 
+L 207.47533 94.820457 
+L 207.47533 82.303249 
+L 219.992538 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_304">
+    <path d="M 219.992538 82.303249 
+L 219.992538 94.820457 
+L 207.47533 94.820457 
+L 207.47533 82.303249 
+L 219.992538 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_305">
+    <path d="M 232.509746 82.303249 
+L 232.509746 94.820457 
+L 219.992538 94.820457 
+L 219.992538 82.303249 
+L 232.509746 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_306">
+    <path d="M 232.509746 82.303249 
+L 232.509746 94.820457 
+L 219.992538 94.820457 
+L 219.992538 82.303249 
+L 232.509746 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_307">
+    <path d="M 245.026954 82.303249 
+L 245.026954 94.820457 
+L 232.509746 94.820457 
+L 232.509746 82.303249 
+L 245.026954 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_308">
+    <path d="M 245.026954 82.303249 
+L 245.026954 94.820457 
+L 232.509746 94.820457 
+L 232.509746 82.303249 
+L 245.026954 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_309">
+    <path d="M 257.544162 82.303249 
+L 257.544162 94.820457 
+L 245.026954 94.820457 
+L 245.026954 82.303249 
+L 257.544162 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_310">
+    <path d="M 257.544162 82.303249 
+L 257.544162 94.820457 
+L 245.026954 94.820457 
+L 245.026954 82.303249 
+L 257.544162 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_311">
+    <path d="M 270.06137 82.303249 
+L 270.06137 94.820457 
+L 257.544162 94.820457 
+L 257.544162 82.303249 
+L 270.06137 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_312">
+    <path d="M 270.06137 82.303249 
+L 270.06137 94.820457 
+L 257.544162 94.820457 
+L 257.544162 82.303249 
+L 270.06137 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_313">
+    <path d="M 282.578578 82.303249 
+L 282.578578 94.820457 
+L 270.06137 94.820457 
+L 270.06137 82.303249 
+L 282.578578 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_314">
+    <path d="M 282.578578 82.303249 
+L 282.578578 94.820457 
+L 270.06137 94.820457 
+L 270.06137 82.303249 
+L 282.578578 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_315">
+    <path d="M 295.095786 82.303249 
+L 295.095786 94.820457 
+L 282.578578 94.820457 
+L 282.578578 82.303249 
+L 295.095786 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_316">
+    <path d="M 295.095786 82.303249 
+L 295.095786 94.820457 
+L 282.578578 94.820457 
+L 282.578578 82.303249 
+L 295.095786 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_317">
+    <path d="M 307.612994 82.303249 
+L 307.612994 94.820457 
+L 295.095786 94.820457 
+L 295.095786 82.303249 
+L 307.612994 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_318">
+    <path d="M 307.612994 82.303249 
+L 307.612994 94.820457 
+L 295.095786 94.820457 
+L 295.095786 82.303249 
+L 307.612994 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_319">
+    <path d="M 320.130203 82.303249 
+L 320.130203 94.820457 
+L 307.612994 94.820457 
+L 307.612994 82.303249 
+L 320.130203 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_320">
+    <path d="M 320.130203 82.303249 
+L 320.130203 94.820457 
+L 307.612994 94.820457 
+L 307.612994 82.303249 
+L 320.130203 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_321">
+    <path d="M 332.647411 82.303249 
+L 332.647411 94.820457 
+L 320.130203 94.820457 
+L 320.130203 82.303249 
+L 332.647411 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_322">
+    <path d="M 332.647411 82.303249 
+L 332.647411 94.820457 
+L 320.130203 94.820457 
+L 320.130203 82.303249 
+L 332.647411 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_323">
+    <path d="M 345.164619 82.303249 
+L 345.164619 94.820457 
+L 332.647411 94.820457 
+L 332.647411 82.303249 
+L 345.164619 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_324">
+    <path d="M 345.164619 82.303249 
+L 345.164619 94.820457 
+L 332.647411 94.820457 
+L 332.647411 82.303249 
+L 345.164619 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_325">
+    <path d="M 357.681827 82.303249 
+L 357.681827 94.820457 
+L 345.164619 94.820457 
+L 345.164619 82.303249 
+L 357.681827 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_326">
+    <path d="M 357.681827 82.303249 
+L 357.681827 94.820457 
+L 345.164619 94.820457 
+L 345.164619 82.303249 
+L 357.681827 82.303249 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_327">
+    <path d="M 32.234416 94.820457 
+L 32.234416 107.337665 
+L 19.717208 107.337665 
+L 19.717208 94.820457 
+L 32.234416 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_328">
+    <path d="M 32.234416 94.820457 
+L 32.234416 107.337665 
+L 19.717208 107.337665 
+L 19.717208 94.820457 
+L 32.234416 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_329">
+    <path d="M 44.751624 94.820457 
+L 44.751624 107.337665 
+L 32.234416 107.337665 
+L 32.234416 94.820457 
+L 44.751624 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_330">
+    <path d="M 44.751624 94.820457 
+L 44.751624 107.337665 
+L 32.234416 107.337665 
+L 32.234416 94.820457 
+L 44.751624 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_331">
+    <path d="M 57.268832 94.820457 
+L 57.268832 107.337665 
+L 44.751624 107.337665 
+L 44.751624 94.820457 
+L 57.268832 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_332">
+    <path d="M 57.268832 94.820457 
+L 57.268832 107.337665 
+L 44.751624 107.337665 
+L 44.751624 94.820457 
+L 57.268832 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_333">
+    <path d="M 69.786041 94.820457 
+L 69.786041 107.337665 
+L 57.268832 107.337665 
+L 57.268832 94.820457 
+L 69.786041 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_334">
+    <path d="M 69.786041 94.820457 
+L 69.786041 107.337665 
+L 57.268832 107.337665 
+L 57.268832 94.820457 
+L 69.786041 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_335">
+    <path d="M 82.303249 94.820457 
+L 82.303249 107.337665 
+L 69.786041 107.337665 
+L 69.786041 94.820457 
+L 82.303249 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_336">
+    <path d="M 82.303249 94.820457 
+L 82.303249 107.337665 
+L 69.786041 107.337665 
+L 69.786041 94.820457 
+L 82.303249 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_337">
+    <path d="M 94.820457 94.820457 
+L 94.820457 107.337665 
+L 82.303249 107.337665 
+L 82.303249 94.820457 
+L 94.820457 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_338">
+    <path d="M 94.820457 94.820457 
+L 94.820457 107.337665 
+L 82.303249 107.337665 
+L 82.303249 94.820457 
+L 94.820457 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_339">
+    <path d="M 107.337665 94.820457 
+L 107.337665 107.337665 
+L 94.820457 107.337665 
+L 94.820457 94.820457 
+L 107.337665 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_340">
+    <path d="M 107.337665 94.820457 
+L 107.337665 107.337665 
+L 94.820457 107.337665 
+L 94.820457 94.820457 
+L 107.337665 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_341">
+    <path d="M 119.854873 94.820457 
+L 119.854873 107.337665 
+L 107.337665 107.337665 
+L 107.337665 94.820457 
+L 119.854873 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_342">
+    <path d="M 119.854873 94.820457 
+L 119.854873 107.337665 
+L 107.337665 107.337665 
+L 107.337665 94.820457 
+L 119.854873 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_343">
+    <path d="M 132.372081 94.820457 
+L 132.372081 107.337665 
+L 119.854873 107.337665 
+L 119.854873 94.820457 
+L 132.372081 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_344">
+    <path d="M 132.372081 94.820457 
+L 132.372081 107.337665 
+L 119.854873 107.337665 
+L 119.854873 94.820457 
+L 132.372081 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_345">
+    <path d="M 144.889289 94.820457 
+L 144.889289 107.337665 
+L 132.372081 107.337665 
+L 132.372081 94.820457 
+L 144.889289 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_346">
+    <path d="M 144.889289 94.820457 
+L 144.889289 107.337665 
+L 132.372081 107.337665 
+L 132.372081 94.820457 
+L 144.889289 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_347">
+    <path d="M 157.406497 94.820457 
+L 157.406497 107.337665 
+L 144.889289 107.337665 
+L 144.889289 94.820457 
+L 157.406497 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_348">
+    <path d="M 157.406497 94.820457 
+L 157.406497 107.337665 
+L 144.889289 107.337665 
+L 144.889289 94.820457 
+L 157.406497 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_349">
+    <path d="M 169.923705 94.820457 
+L 169.923705 107.337665 
+L 157.406497 107.337665 
+L 157.406497 94.820457 
+L 169.923705 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_350">
+    <path d="M 169.923705 94.820457 
+L 169.923705 107.337665 
+L 157.406497 107.337665 
+L 157.406497 94.820457 
+L 169.923705 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_351">
+    <path d="M 182.440913 94.820457 
+L 182.440913 107.337665 
+L 169.923705 107.337665 
+L 169.923705 94.820457 
+L 182.440913 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_352">
+    <path d="M 182.440913 94.820457 
+L 182.440913 107.337665 
+L 169.923705 107.337665 
+L 169.923705 94.820457 
+L 182.440913 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_353">
+    <path d="M 194.958122 94.820457 
+L 194.958122 107.337665 
+L 182.440913 107.337665 
+L 182.440913 94.820457 
+L 194.958122 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_354">
+    <path d="M 194.958122 94.820457 
+L 194.958122 107.337665 
+L 182.440913 107.337665 
+L 182.440913 94.820457 
+L 194.958122 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_355">
+    <path d="M 207.47533 94.820457 
+L 207.47533 107.337665 
+L 194.958122 107.337665 
+L 194.958122 94.820457 
+L 207.47533 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_356">
+    <path d="M 207.47533 94.820457 
+L 207.47533 107.337665 
+L 194.958122 107.337665 
+L 194.958122 94.820457 
+L 207.47533 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_357">
+    <path d="M 219.992538 94.820457 
+L 219.992538 107.337665 
+L 207.47533 107.337665 
+L 207.47533 94.820457 
+L 219.992538 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_358">
+    <path d="M 219.992538 94.820457 
+L 219.992538 107.337665 
+L 207.47533 107.337665 
+L 207.47533 94.820457 
+L 219.992538 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_359">
+    <path d="M 232.509746 94.820457 
+L 232.509746 107.337665 
+L 219.992538 107.337665 
+L 219.992538 94.820457 
+L 232.509746 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_360">
+    <path d="M 232.509746 94.820457 
+L 232.509746 107.337665 
+L 219.992538 107.337665 
+L 219.992538 94.820457 
+L 232.509746 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_361">
+    <path d="M 245.026954 94.820457 
+L 245.026954 107.337665 
+L 232.509746 107.337665 
+L 232.509746 94.820457 
+L 245.026954 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_362">
+    <path d="M 245.026954 94.820457 
+L 245.026954 107.337665 
+L 232.509746 107.337665 
+L 232.509746 94.820457 
+L 245.026954 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_363">
+    <path d="M 257.544162 94.820457 
+L 257.544162 107.337665 
+L 245.026954 107.337665 
+L 245.026954 94.820457 
+L 257.544162 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_364">
+    <path d="M 257.544162 94.820457 
+L 257.544162 107.337665 
+L 245.026954 107.337665 
+L 245.026954 94.820457 
+L 257.544162 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_365">
+    <path d="M 270.06137 94.820457 
+L 270.06137 107.337665 
+L 257.544162 107.337665 
+L 257.544162 94.820457 
+L 270.06137 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_366">
+    <path d="M 270.06137 94.820457 
+L 270.06137 107.337665 
+L 257.544162 107.337665 
+L 257.544162 94.820457 
+L 270.06137 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_367">
+    <path d="M 282.578578 94.820457 
+L 282.578578 107.337665 
+L 270.06137 107.337665 
+L 270.06137 94.820457 
+L 282.578578 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_368">
+    <path d="M 282.578578 94.820457 
+L 282.578578 107.337665 
+L 270.06137 107.337665 
+L 270.06137 94.820457 
+L 282.578578 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_369">
+    <path d="M 295.095786 94.820457 
+L 295.095786 107.337665 
+L 282.578578 107.337665 
+L 282.578578 94.820457 
+L 295.095786 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_370">
+    <path d="M 295.095786 94.820457 
+L 295.095786 107.337665 
+L 282.578578 107.337665 
+L 282.578578 94.820457 
+L 295.095786 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_371">
+    <path d="M 307.612994 94.820457 
+L 307.612994 107.337665 
+L 295.095786 107.337665 
+L 295.095786 94.820457 
+L 307.612994 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_372">
+    <path d="M 307.612994 94.820457 
+L 307.612994 107.337665 
+L 295.095786 107.337665 
+L 295.095786 94.820457 
+L 307.612994 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_373">
+    <path d="M 320.130203 94.820457 
+L 320.130203 107.337665 
+L 307.612994 107.337665 
+L 307.612994 94.820457 
+L 320.130203 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_374">
+    <path d="M 320.130203 94.820457 
+L 320.130203 107.337665 
+L 307.612994 107.337665 
+L 307.612994 94.820457 
+L 320.130203 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_375">
+    <path d="M 332.647411 94.820457 
+L 332.647411 107.337665 
+L 320.130203 107.337665 
+L 320.130203 94.820457 
+L 332.647411 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_376">
+    <path d="M 332.647411 94.820457 
+L 332.647411 107.337665 
+L 320.130203 107.337665 
+L 320.130203 94.820457 
+L 332.647411 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_377">
+    <path d="M 345.164619 94.820457 
+L 345.164619 107.337665 
+L 332.647411 107.337665 
+L 332.647411 94.820457 
+L 345.164619 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_378">
+    <path d="M 345.164619 94.820457 
+L 345.164619 107.337665 
+L 332.647411 107.337665 
+L 332.647411 94.820457 
+L 345.164619 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_379">
+    <path d="M 357.681827 94.820457 
+L 357.681827 107.337665 
+L 345.164619 107.337665 
+L 345.164619 94.820457 
+L 357.681827 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_380">
+    <path d="M 357.681827 94.820457 
+L 357.681827 107.337665 
+L 345.164619 107.337665 
+L 345.164619 94.820457 
+L 357.681827 94.820457 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_381">
+    <path d="M 32.234416 107.337665 
+L 32.234416 119.854873 
+L 19.717208 119.854873 
+L 19.717208 107.337665 
+L 32.234416 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_382">
+    <path d="M 32.234416 107.337665 
+L 32.234416 119.854873 
+L 19.717208 119.854873 
+L 19.717208 107.337665 
+L 32.234416 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_383">
+    <path d="M 44.751624 107.337665 
+L 44.751624 119.854873 
+L 32.234416 119.854873 
+L 32.234416 107.337665 
+L 44.751624 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_384">
+    <path d="M 44.751624 107.337665 
+L 44.751624 119.854873 
+L 32.234416 119.854873 
+L 32.234416 107.337665 
+L 44.751624 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_385">
+    <path d="M 57.268832 107.337665 
+L 57.268832 119.854873 
+L 44.751624 119.854873 
+L 44.751624 107.337665 
+L 57.268832 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_386">
+    <path d="M 57.268832 107.337665 
+L 57.268832 119.854873 
+L 44.751624 119.854873 
+L 44.751624 107.337665 
+L 57.268832 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_387">
+    <path d="M 69.786041 107.337665 
+L 69.786041 119.854873 
+L 57.268832 119.854873 
+L 57.268832 107.337665 
+L 69.786041 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_388">
+    <path d="M 69.786041 107.337665 
+L 69.786041 119.854873 
+L 57.268832 119.854873 
+L 57.268832 107.337665 
+L 69.786041 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_389">
+    <path d="M 82.303249 107.337665 
+L 82.303249 119.854873 
+L 69.786041 119.854873 
+L 69.786041 107.337665 
+L 82.303249 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_390">
+    <path d="M 82.303249 107.337665 
+L 82.303249 119.854873 
+L 69.786041 119.854873 
+L 69.786041 107.337665 
+L 82.303249 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_391">
+    <path d="M 94.820457 107.337665 
+L 94.820457 119.854873 
+L 82.303249 119.854873 
+L 82.303249 107.337665 
+L 94.820457 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_392">
+    <path d="M 94.820457 107.337665 
+L 94.820457 119.854873 
+L 82.303249 119.854873 
+L 82.303249 107.337665 
+L 94.820457 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_393">
+    <path d="M 107.337665 107.337665 
+L 107.337665 119.854873 
+L 94.820457 119.854873 
+L 94.820457 107.337665 
+L 107.337665 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_394">
+    <path d="M 107.337665 107.337665 
+L 107.337665 119.854873 
+L 94.820457 119.854873 
+L 94.820457 107.337665 
+L 107.337665 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_395">
+    <path d="M 119.854873 107.337665 
+L 119.854873 119.854873 
+L 107.337665 119.854873 
+L 107.337665 107.337665 
+L 119.854873 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_396">
+    <path d="M 119.854873 107.337665 
+L 119.854873 119.854873 
+L 107.337665 119.854873 
+L 107.337665 107.337665 
+L 119.854873 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_397">
+    <path d="M 132.372081 107.337665 
+L 132.372081 119.854873 
+L 119.854873 119.854873 
+L 119.854873 107.337665 
+L 132.372081 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_398">
+    <path d="M 132.372081 107.337665 
+L 132.372081 119.854873 
+L 119.854873 119.854873 
+L 119.854873 107.337665 
+L 132.372081 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_399">
+    <path d="M 144.889289 107.337665 
+L 144.889289 119.854873 
+L 132.372081 119.854873 
+L 132.372081 107.337665 
+L 144.889289 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_400">
+    <path d="M 144.889289 107.337665 
+L 144.889289 119.854873 
+L 132.372081 119.854873 
+L 132.372081 107.337665 
+L 144.889289 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_401">
+    <path d="M 157.406497 107.337665 
+L 157.406497 119.854873 
+L 144.889289 119.854873 
+L 144.889289 107.337665 
+L 157.406497 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_402">
+    <path d="M 157.406497 107.337665 
+L 157.406497 119.854873 
+L 144.889289 119.854873 
+L 144.889289 107.337665 
+L 157.406497 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_403">
+    <path d="M 169.923705 107.337665 
+L 169.923705 119.854873 
+L 157.406497 119.854873 
+L 157.406497 107.337665 
+L 169.923705 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_404">
+    <path d="M 169.923705 107.337665 
+L 169.923705 119.854873 
+L 157.406497 119.854873 
+L 157.406497 107.337665 
+L 169.923705 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_405">
+    <path d="M 182.440913 107.337665 
+L 182.440913 119.854873 
+L 169.923705 119.854873 
+L 169.923705 107.337665 
+L 182.440913 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_406">
+    <path d="M 182.440913 107.337665 
+L 182.440913 119.854873 
+L 169.923705 119.854873 
+L 169.923705 107.337665 
+L 182.440913 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_407">
+    <path d="M 194.958122 107.337665 
+L 194.958122 119.854873 
+L 182.440913 119.854873 
+L 182.440913 107.337665 
+L 194.958122 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_408">
+    <path d="M 194.958122 107.337665 
+L 194.958122 119.854873 
+L 182.440913 119.854873 
+L 182.440913 107.337665 
+L 194.958122 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_409">
+    <path d="M 207.47533 107.337665 
+L 207.47533 119.854873 
+L 194.958122 119.854873 
+L 194.958122 107.337665 
+L 207.47533 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_410">
+    <path d="M 207.47533 107.337665 
+L 207.47533 119.854873 
+L 194.958122 119.854873 
+L 194.958122 107.337665 
+L 207.47533 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_411">
+    <path d="M 219.992538 107.337665 
+L 219.992538 119.854873 
+L 207.47533 119.854873 
+L 207.47533 107.337665 
+L 219.992538 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_412">
+    <path d="M 219.992538 107.337665 
+L 219.992538 119.854873 
+L 207.47533 119.854873 
+L 207.47533 107.337665 
+L 219.992538 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_413">
+    <path d="M 232.509746 107.337665 
+L 232.509746 119.854873 
+L 219.992538 119.854873 
+L 219.992538 107.337665 
+L 232.509746 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_414">
+    <path d="M 232.509746 107.337665 
+L 232.509746 119.854873 
+L 219.992538 119.854873 
+L 219.992538 107.337665 
+L 232.509746 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_415">
+    <path d="M 245.026954 107.337665 
+L 245.026954 119.854873 
+L 232.509746 119.854873 
+L 232.509746 107.337665 
+L 245.026954 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_416">
+    <path d="M 245.026954 107.337665 
+L 245.026954 119.854873 
+L 232.509746 119.854873 
+L 232.509746 107.337665 
+L 245.026954 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_417">
+    <path d="M 257.544162 107.337665 
+L 257.544162 119.854873 
+L 245.026954 119.854873 
+L 245.026954 107.337665 
+L 257.544162 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_418">
+    <path d="M 257.544162 107.337665 
+L 257.544162 119.854873 
+L 245.026954 119.854873 
+L 245.026954 107.337665 
+L 257.544162 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_419">
+    <path d="M 270.06137 107.337665 
+L 270.06137 119.854873 
+L 257.544162 119.854873 
+L 257.544162 107.337665 
+L 270.06137 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_420">
+    <path d="M 270.06137 107.337665 
+L 270.06137 119.854873 
+L 257.544162 119.854873 
+L 257.544162 107.337665 
+L 270.06137 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_421">
+    <path d="M 282.578578 107.337665 
+L 282.578578 119.854873 
+L 270.06137 119.854873 
+L 270.06137 107.337665 
+L 282.578578 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_422">
+    <path d="M 282.578578 107.337665 
+L 282.578578 119.854873 
+L 270.06137 119.854873 
+L 270.06137 107.337665 
+L 282.578578 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_423">
+    <path d="M 295.095786 107.337665 
+L 295.095786 119.854873 
+L 282.578578 119.854873 
+L 282.578578 107.337665 
+L 295.095786 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_424">
+    <path d="M 295.095786 107.337665 
+L 295.095786 119.854873 
+L 282.578578 119.854873 
+L 282.578578 107.337665 
+L 295.095786 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_425">
+    <path d="M 307.612994 107.337665 
+L 307.612994 119.854873 
+L 295.095786 119.854873 
+L 295.095786 107.337665 
+L 307.612994 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_426">
+    <path d="M 307.612994 107.337665 
+L 307.612994 119.854873 
+L 295.095786 119.854873 
+L 295.095786 107.337665 
+L 307.612994 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_427">
+    <path d="M 320.130203 107.337665 
+L 320.130203 119.854873 
+L 307.612994 119.854873 
+L 307.612994 107.337665 
+L 320.130203 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_428">
+    <path d="M 320.130203 107.337665 
+L 320.130203 119.854873 
+L 307.612994 119.854873 
+L 307.612994 107.337665 
+L 320.130203 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_429">
+    <path d="M 332.647411 107.337665 
+L 332.647411 119.854873 
+L 320.130203 119.854873 
+L 320.130203 107.337665 
+L 332.647411 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_430">
+    <path d="M 332.647411 107.337665 
+L 332.647411 119.854873 
+L 320.130203 119.854873 
+L 320.130203 107.337665 
+L 332.647411 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_431">
+    <path d="M 345.164619 107.337665 
+L 345.164619 119.854873 
+L 332.647411 119.854873 
+L 332.647411 107.337665 
+L 345.164619 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_432">
+    <path d="M 345.164619 107.337665 
+L 345.164619 119.854873 
+L 332.647411 119.854873 
+L 332.647411 107.337665 
+L 345.164619 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_433">
+    <path d="M 357.681827 107.337665 
+L 357.681827 119.854873 
+L 345.164619 119.854873 
+L 345.164619 107.337665 
+L 357.681827 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_434">
+    <path d="M 357.681827 107.337665 
+L 357.681827 119.854873 
+L 345.164619 119.854873 
+L 345.164619 107.337665 
+L 357.681827 107.337665 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_435">
+    <path d="M 32.234416 119.854873 
+L 32.234416 132.372081 
+L 19.717208 132.372081 
+L 19.717208 119.854873 
+L 32.234416 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_436">
+    <path d="M 32.234416 119.854873 
+L 32.234416 132.372081 
+L 19.717208 132.372081 
+L 19.717208 119.854873 
+L 32.234416 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_437">
+    <path d="M 44.751624 119.854873 
+L 44.751624 132.372081 
+L 32.234416 132.372081 
+L 32.234416 119.854873 
+L 44.751624 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_438">
+    <path d="M 44.751624 119.854873 
+L 44.751624 132.372081 
+L 32.234416 132.372081 
+L 32.234416 119.854873 
+L 44.751624 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_439">
+    <path d="M 57.268832 119.854873 
+L 57.268832 132.372081 
+L 44.751624 132.372081 
+L 44.751624 119.854873 
+L 57.268832 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_440">
+    <path d="M 57.268832 119.854873 
+L 57.268832 132.372081 
+L 44.751624 132.372081 
+L 44.751624 119.854873 
+L 57.268832 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_441">
+    <path d="M 69.786041 119.854873 
+L 69.786041 132.372081 
+L 57.268832 132.372081 
+L 57.268832 119.854873 
+L 69.786041 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_442">
+    <path d="M 69.786041 119.854873 
+L 69.786041 132.372081 
+L 57.268832 132.372081 
+L 57.268832 119.854873 
+L 69.786041 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_443">
+    <path d="M 82.303249 119.854873 
+L 82.303249 132.372081 
+L 69.786041 132.372081 
+L 69.786041 119.854873 
+L 82.303249 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_444">
+    <path d="M 82.303249 119.854873 
+L 82.303249 132.372081 
+L 69.786041 132.372081 
+L 69.786041 119.854873 
+L 82.303249 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_445">
+    <path d="M 94.820457 119.854873 
+L 94.820457 132.372081 
+L 82.303249 132.372081 
+L 82.303249 119.854873 
+L 94.820457 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_446">
+    <path d="M 94.820457 119.854873 
+L 94.820457 132.372081 
+L 82.303249 132.372081 
+L 82.303249 119.854873 
+L 94.820457 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_447">
+    <path d="M 107.337665 119.854873 
+L 107.337665 132.372081 
+L 94.820457 132.372081 
+L 94.820457 119.854873 
+L 107.337665 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_448">
+    <path d="M 107.337665 119.854873 
+L 107.337665 132.372081 
+L 94.820457 132.372081 
+L 94.820457 119.854873 
+L 107.337665 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_449">
+    <path d="M 119.854873 119.854873 
+L 119.854873 132.372081 
+L 107.337665 132.372081 
+L 107.337665 119.854873 
+L 119.854873 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_450">
+    <path d="M 119.854873 119.854873 
+L 119.854873 132.372081 
+L 107.337665 132.372081 
+L 107.337665 119.854873 
+L 119.854873 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_451">
+    <path d="M 132.372081 119.854873 
+L 132.372081 132.372081 
+L 119.854873 132.372081 
+L 119.854873 119.854873 
+L 132.372081 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_452">
+    <path d="M 132.372081 119.854873 
+L 132.372081 132.372081 
+L 119.854873 132.372081 
+L 119.854873 119.854873 
+L 132.372081 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_453">
+    <path d="M 144.889289 119.854873 
+L 144.889289 132.372081 
+L 132.372081 132.372081 
+L 132.372081 119.854873 
+L 144.889289 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_454">
+    <path d="M 144.889289 119.854873 
+L 144.889289 132.372081 
+L 132.372081 132.372081 
+L 132.372081 119.854873 
+L 144.889289 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_455">
+    <path d="M 157.406497 119.854873 
+L 157.406497 132.372081 
+L 144.889289 132.372081 
+L 144.889289 119.854873 
+L 157.406497 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_456">
+    <path d="M 157.406497 119.854873 
+L 157.406497 132.372081 
+L 144.889289 132.372081 
+L 144.889289 119.854873 
+L 157.406497 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_457">
+    <path d="M 169.923705 119.854873 
+L 169.923705 132.372081 
+L 157.406497 132.372081 
+L 157.406497 119.854873 
+L 169.923705 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_458">
+    <path d="M 169.923705 119.854873 
+L 169.923705 132.372081 
+L 157.406497 132.372081 
+L 157.406497 119.854873 
+L 169.923705 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_459">
+    <path d="M 182.440913 119.854873 
+L 182.440913 132.372081 
+L 169.923705 132.372081 
+L 169.923705 119.854873 
+L 182.440913 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_460">
+    <path d="M 182.440913 119.854873 
+L 182.440913 132.372081 
+L 169.923705 132.372081 
+L 169.923705 119.854873 
+L 182.440913 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_461">
+    <path d="M 194.958122 119.854873 
+L 194.958122 132.372081 
+L 182.440913 132.372081 
+L 182.440913 119.854873 
+L 194.958122 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_462">
+    <path d="M 194.958122 119.854873 
+L 194.958122 132.372081 
+L 182.440913 132.372081 
+L 182.440913 119.854873 
+L 194.958122 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_463">
+    <path d="M 207.47533 119.854873 
+L 207.47533 132.372081 
+L 194.958122 132.372081 
+L 194.958122 119.854873 
+L 207.47533 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_464">
+    <path d="M 207.47533 119.854873 
+L 207.47533 132.372081 
+L 194.958122 132.372081 
+L 194.958122 119.854873 
+L 207.47533 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_465">
+    <path d="M 219.992538 119.854873 
+L 219.992538 132.372081 
+L 207.47533 132.372081 
+L 207.47533 119.854873 
+L 219.992538 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_466">
+    <path d="M 219.992538 119.854873 
+L 219.992538 132.372081 
+L 207.47533 132.372081 
+L 207.47533 119.854873 
+L 219.992538 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_467">
+    <path d="M 232.509746 119.854873 
+L 232.509746 132.372081 
+L 219.992538 132.372081 
+L 219.992538 119.854873 
+L 232.509746 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_468">
+    <path d="M 232.509746 119.854873 
+L 232.509746 132.372081 
+L 219.992538 132.372081 
+L 219.992538 119.854873 
+L 232.509746 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_469">
+    <path d="M 245.026954 119.854873 
+L 245.026954 132.372081 
+L 232.509746 132.372081 
+L 232.509746 119.854873 
+L 245.026954 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_470">
+    <path d="M 245.026954 119.854873 
+L 245.026954 132.372081 
+L 232.509746 132.372081 
+L 232.509746 119.854873 
+L 245.026954 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_471">
+    <path d="M 257.544162 119.854873 
+L 257.544162 132.372081 
+L 245.026954 132.372081 
+L 245.026954 119.854873 
+L 257.544162 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_472">
+    <path d="M 257.544162 119.854873 
+L 257.544162 132.372081 
+L 245.026954 132.372081 
+L 245.026954 119.854873 
+L 257.544162 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_473">
+    <path d="M 270.06137 119.854873 
+L 270.06137 132.372081 
+L 257.544162 132.372081 
+L 257.544162 119.854873 
+L 270.06137 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_474">
+    <path d="M 270.06137 119.854873 
+L 270.06137 132.372081 
+L 257.544162 132.372081 
+L 257.544162 119.854873 
+L 270.06137 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_475">
+    <path d="M 282.578578 119.854873 
+L 282.578578 132.372081 
+L 270.06137 132.372081 
+L 270.06137 119.854873 
+L 282.578578 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_476">
+    <path d="M 282.578578 119.854873 
+L 282.578578 132.372081 
+L 270.06137 132.372081 
+L 270.06137 119.854873 
+L 282.578578 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_477">
+    <path d="M 295.095786 119.854873 
+L 295.095786 132.372081 
+L 282.578578 132.372081 
+L 282.578578 119.854873 
+L 295.095786 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_478">
+    <path d="M 295.095786 119.854873 
+L 295.095786 132.372081 
+L 282.578578 132.372081 
+L 282.578578 119.854873 
+L 295.095786 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_479">
+    <path d="M 307.612994 119.854873 
+L 307.612994 132.372081 
+L 295.095786 132.372081 
+L 295.095786 119.854873 
+L 307.612994 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_480">
+    <path d="M 307.612994 119.854873 
+L 307.612994 132.372081 
+L 295.095786 132.372081 
+L 295.095786 119.854873 
+L 307.612994 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_481">
+    <path d="M 320.130203 119.854873 
+L 320.130203 132.372081 
+L 307.612994 132.372081 
+L 307.612994 119.854873 
+L 320.130203 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_482">
+    <path d="M 320.130203 119.854873 
+L 320.130203 132.372081 
+L 307.612994 132.372081 
+L 307.612994 119.854873 
+L 320.130203 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_483">
+    <path d="M 332.647411 119.854873 
+L 332.647411 132.372081 
+L 320.130203 132.372081 
+L 320.130203 119.854873 
+L 332.647411 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_484">
+    <path d="M 332.647411 119.854873 
+L 332.647411 132.372081 
+L 320.130203 132.372081 
+L 320.130203 119.854873 
+L 332.647411 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_485">
+    <path d="M 345.164619 119.854873 
+L 345.164619 132.372081 
+L 332.647411 132.372081 
+L 332.647411 119.854873 
+L 345.164619 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_486">
+    <path d="M 345.164619 119.854873 
+L 345.164619 132.372081 
+L 332.647411 132.372081 
+L 332.647411 119.854873 
+L 345.164619 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_487">
+    <path d="M 357.681827 119.854873 
+L 357.681827 132.372081 
+L 345.164619 132.372081 
+L 345.164619 119.854873 
+L 357.681827 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_488">
+    <path d="M 357.681827 119.854873 
+L 357.681827 132.372081 
+L 345.164619 132.372081 
+L 345.164619 119.854873 
+L 357.681827 119.854873 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_489">
+    <path d="M 32.234416 132.372081 
+L 32.234416 144.889289 
+L 19.717208 144.889289 
+L 19.717208 132.372081 
+L 32.234416 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_490">
+    <path d="M 32.234416 132.372081 
+L 32.234416 144.889289 
+L 19.717208 144.889289 
+L 19.717208 132.372081 
+L 32.234416 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_491">
+    <path d="M 44.751624 132.372081 
+L 44.751624 144.889289 
+L 32.234416 144.889289 
+L 32.234416 132.372081 
+L 44.751624 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_492">
+    <path d="M 44.751624 132.372081 
+L 44.751624 144.889289 
+L 32.234416 144.889289 
+L 32.234416 132.372081 
+L 44.751624 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_493">
+    <path d="M 57.268832 132.372081 
+L 57.268832 144.889289 
+L 44.751624 144.889289 
+L 44.751624 132.372081 
+L 57.268832 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_494">
+    <path d="M 57.268832 132.372081 
+L 57.268832 144.889289 
+L 44.751624 144.889289 
+L 44.751624 132.372081 
+L 57.268832 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_495">
+    <path d="M 69.786041 132.372081 
+L 69.786041 144.889289 
+L 57.268832 144.889289 
+L 57.268832 132.372081 
+L 69.786041 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_496">
+    <path d="M 69.786041 132.372081 
+L 69.786041 144.889289 
+L 57.268832 144.889289 
+L 57.268832 132.372081 
+L 69.786041 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_497">
+    <path d="M 82.303249 132.372081 
+L 82.303249 144.889289 
+L 69.786041 144.889289 
+L 69.786041 132.372081 
+L 82.303249 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_498">
+    <path d="M 82.303249 132.372081 
+L 82.303249 144.889289 
+L 69.786041 144.889289 
+L 69.786041 132.372081 
+L 82.303249 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_499">
+    <path d="M 94.820457 132.372081 
+L 94.820457 144.889289 
+L 82.303249 144.889289 
+L 82.303249 132.372081 
+L 94.820457 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_500">
+    <path d="M 94.820457 132.372081 
+L 94.820457 144.889289 
+L 82.303249 144.889289 
+L 82.303249 132.372081 
+L 94.820457 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_501">
+    <path d="M 107.337665 132.372081 
+L 107.337665 144.889289 
+L 94.820457 144.889289 
+L 94.820457 132.372081 
+L 107.337665 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_502">
+    <path d="M 107.337665 132.372081 
+L 107.337665 144.889289 
+L 94.820457 144.889289 
+L 94.820457 132.372081 
+L 107.337665 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_503">
+    <path d="M 119.854873 132.372081 
+L 119.854873 144.889289 
+L 107.337665 144.889289 
+L 107.337665 132.372081 
+L 119.854873 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_504">
+    <path d="M 119.854873 132.372081 
+L 119.854873 144.889289 
+L 107.337665 144.889289 
+L 107.337665 132.372081 
+L 119.854873 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_505">
+    <path d="M 132.372081 132.372081 
+L 132.372081 144.889289 
+L 119.854873 144.889289 
+L 119.854873 132.372081 
+L 132.372081 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_506">
+    <path d="M 132.372081 132.372081 
+L 132.372081 144.889289 
+L 119.854873 144.889289 
+L 119.854873 132.372081 
+L 132.372081 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_507">
+    <path d="M 144.889289 132.372081 
+L 144.889289 144.889289 
+L 132.372081 144.889289 
+L 132.372081 132.372081 
+L 144.889289 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_508">
+    <path d="M 144.889289 132.372081 
+L 144.889289 144.889289 
+L 132.372081 144.889289 
+L 132.372081 132.372081 
+L 144.889289 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_509">
+    <path d="M 157.406497 132.372081 
+L 157.406497 144.889289 
+L 144.889289 144.889289 
+L 144.889289 132.372081 
+L 157.406497 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_510">
+    <path d="M 157.406497 132.372081 
+L 157.406497 144.889289 
+L 144.889289 144.889289 
+L 144.889289 132.372081 
+L 157.406497 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_511">
+    <path d="M 169.923705 132.372081 
+L 169.923705 144.889289 
+L 157.406497 144.889289 
+L 157.406497 132.372081 
+L 169.923705 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_512">
+    <path d="M 169.923705 132.372081 
+L 169.923705 144.889289 
+L 157.406497 144.889289 
+L 157.406497 132.372081 
+L 169.923705 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_513">
+    <path d="M 182.440913 132.372081 
+L 182.440913 144.889289 
+L 169.923705 144.889289 
+L 169.923705 132.372081 
+L 182.440913 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_514">
+    <path d="M 182.440913 132.372081 
+L 182.440913 144.889289 
+L 169.923705 144.889289 
+L 169.923705 132.372081 
+L 182.440913 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_515">
+    <path d="M 194.958122 132.372081 
+L 194.958122 144.889289 
+L 182.440913 144.889289 
+L 182.440913 132.372081 
+L 194.958122 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_516">
+    <path d="M 194.958122 132.372081 
+L 194.958122 144.889289 
+L 182.440913 144.889289 
+L 182.440913 132.372081 
+L 194.958122 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_517">
+    <path d="M 207.47533 132.372081 
+L 207.47533 144.889289 
+L 194.958122 144.889289 
+L 194.958122 132.372081 
+L 207.47533 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_518">
+    <path d="M 207.47533 132.372081 
+L 207.47533 144.889289 
+L 194.958122 144.889289 
+L 194.958122 132.372081 
+L 207.47533 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_519">
+    <path d="M 219.992538 132.372081 
+L 219.992538 144.889289 
+L 207.47533 144.889289 
+L 207.47533 132.372081 
+L 219.992538 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_520">
+    <path d="M 219.992538 132.372081 
+L 219.992538 144.889289 
+L 207.47533 144.889289 
+L 207.47533 132.372081 
+L 219.992538 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_521">
+    <path d="M 232.509746 132.372081 
+L 232.509746 144.889289 
+L 219.992538 144.889289 
+L 219.992538 132.372081 
+L 232.509746 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_522">
+    <path d="M 232.509746 132.372081 
+L 232.509746 144.889289 
+L 219.992538 144.889289 
+L 219.992538 132.372081 
+L 232.509746 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_523">
+    <path d="M 245.026954 132.372081 
+L 245.026954 144.889289 
+L 232.509746 144.889289 
+L 232.509746 132.372081 
+L 245.026954 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_524">
+    <path d="M 245.026954 132.372081 
+L 245.026954 144.889289 
+L 232.509746 144.889289 
+L 232.509746 132.372081 
+L 245.026954 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_525">
+    <path d="M 257.544162 132.372081 
+L 257.544162 144.889289 
+L 245.026954 144.889289 
+L 245.026954 132.372081 
+L 257.544162 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_526">
+    <path d="M 257.544162 132.372081 
+L 257.544162 144.889289 
+L 245.026954 144.889289 
+L 245.026954 132.372081 
+L 257.544162 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_527">
+    <path d="M 270.06137 132.372081 
+L 270.06137 144.889289 
+L 257.544162 144.889289 
+L 257.544162 132.372081 
+L 270.06137 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_528">
+    <path d="M 270.06137 132.372081 
+L 270.06137 144.889289 
+L 257.544162 144.889289 
+L 257.544162 132.372081 
+L 270.06137 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_529">
+    <path d="M 282.578578 132.372081 
+L 282.578578 144.889289 
+L 270.06137 144.889289 
+L 270.06137 132.372081 
+L 282.578578 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_530">
+    <path d="M 282.578578 132.372081 
+L 282.578578 144.889289 
+L 270.06137 144.889289 
+L 270.06137 132.372081 
+L 282.578578 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_531">
+    <path d="M 295.095786 132.372081 
+L 295.095786 144.889289 
+L 282.578578 144.889289 
+L 282.578578 132.372081 
+L 295.095786 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_532">
+    <path d="M 295.095786 132.372081 
+L 295.095786 144.889289 
+L 282.578578 144.889289 
+L 282.578578 132.372081 
+L 295.095786 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_533">
+    <path d="M 307.612994 132.372081 
+L 307.612994 144.889289 
+L 295.095786 144.889289 
+L 295.095786 132.372081 
+L 307.612994 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_534">
+    <path d="M 307.612994 132.372081 
+L 307.612994 144.889289 
+L 295.095786 144.889289 
+L 295.095786 132.372081 
+L 307.612994 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_535">
+    <path d="M 320.130203 132.372081 
+L 320.130203 144.889289 
+L 307.612994 144.889289 
+L 307.612994 132.372081 
+L 320.130203 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_536">
+    <path d="M 320.130203 132.372081 
+L 320.130203 144.889289 
+L 307.612994 144.889289 
+L 307.612994 132.372081 
+L 320.130203 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_537">
+    <path d="M 332.647411 132.372081 
+L 332.647411 144.889289 
+L 320.130203 144.889289 
+L 320.130203 132.372081 
+L 332.647411 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_538">
+    <path d="M 332.647411 132.372081 
+L 332.647411 144.889289 
+L 320.130203 144.889289 
+L 320.130203 132.372081 
+L 332.647411 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_539">
+    <path d="M 345.164619 132.372081 
+L 345.164619 144.889289 
+L 332.647411 144.889289 
+L 332.647411 132.372081 
+L 345.164619 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_540">
+    <path d="M 345.164619 132.372081 
+L 345.164619 144.889289 
+L 332.647411 144.889289 
+L 332.647411 132.372081 
+L 345.164619 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_541">
+    <path d="M 357.681827 132.372081 
+L 357.681827 144.889289 
+L 345.164619 144.889289 
+L 345.164619 132.372081 
+L 357.681827 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_542">
+    <path d="M 357.681827 132.372081 
+L 357.681827 144.889289 
+L 345.164619 144.889289 
+L 345.164619 132.372081 
+L 357.681827 132.372081 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_543">
+    <path d="M 32.234416 144.889289 
+L 32.234416 157.406497 
+L 19.717208 157.406497 
+L 19.717208 144.889289 
+L 32.234416 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_544">
+    <path d="M 32.234416 144.889289 
+L 32.234416 157.406497 
+L 19.717208 157.406497 
+L 19.717208 144.889289 
+L 32.234416 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_545">
+    <path d="M 44.751624 144.889289 
+L 44.751624 157.406497 
+L 32.234416 157.406497 
+L 32.234416 144.889289 
+L 44.751624 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_546">
+    <path d="M 44.751624 144.889289 
+L 44.751624 157.406497 
+L 32.234416 157.406497 
+L 32.234416 144.889289 
+L 44.751624 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_547">
+    <path d="M 57.268832 144.889289 
+L 57.268832 157.406497 
+L 44.751624 157.406497 
+L 44.751624 144.889289 
+L 57.268832 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_548">
+    <path d="M 57.268832 144.889289 
+L 57.268832 157.406497 
+L 44.751624 157.406497 
+L 44.751624 144.889289 
+L 57.268832 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_549">
+    <path d="M 69.786041 144.889289 
+L 69.786041 157.406497 
+L 57.268832 157.406497 
+L 57.268832 144.889289 
+L 69.786041 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_550">
+    <path d="M 69.786041 144.889289 
+L 69.786041 157.406497 
+L 57.268832 157.406497 
+L 57.268832 144.889289 
+L 69.786041 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_551">
+    <path d="M 82.303249 144.889289 
+L 82.303249 157.406497 
+L 69.786041 157.406497 
+L 69.786041 144.889289 
+L 82.303249 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_552">
+    <path d="M 82.303249 144.889289 
+L 82.303249 157.406497 
+L 69.786041 157.406497 
+L 69.786041 144.889289 
+L 82.303249 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_553">
+    <path d="M 94.820457 144.889289 
+L 94.820457 157.406497 
+L 82.303249 157.406497 
+L 82.303249 144.889289 
+L 94.820457 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_554">
+    <path d="M 94.820457 144.889289 
+L 94.820457 157.406497 
+L 82.303249 157.406497 
+L 82.303249 144.889289 
+L 94.820457 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_555">
+    <path d="M 107.337665 144.889289 
+L 107.337665 157.406497 
+L 94.820457 157.406497 
+L 94.820457 144.889289 
+L 107.337665 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_556">
+    <path d="M 107.337665 144.889289 
+L 107.337665 157.406497 
+L 94.820457 157.406497 
+L 94.820457 144.889289 
+L 107.337665 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_557">
+    <path d="M 119.854873 144.889289 
+L 119.854873 157.406497 
+L 107.337665 157.406497 
+L 107.337665 144.889289 
+L 119.854873 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_558">
+    <path d="M 119.854873 144.889289 
+L 119.854873 157.406497 
+L 107.337665 157.406497 
+L 107.337665 144.889289 
+L 119.854873 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_559">
+    <path d="M 132.372081 144.889289 
+L 132.372081 157.406497 
+L 119.854873 157.406497 
+L 119.854873 144.889289 
+L 132.372081 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_560">
+    <path d="M 132.372081 144.889289 
+L 132.372081 157.406497 
+L 119.854873 157.406497 
+L 119.854873 144.889289 
+L 132.372081 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_561">
+    <path d="M 144.889289 144.889289 
+L 144.889289 157.406497 
+L 132.372081 157.406497 
+L 132.372081 144.889289 
+L 144.889289 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_562">
+    <path d="M 144.889289 144.889289 
+L 144.889289 157.406497 
+L 132.372081 157.406497 
+L 132.372081 144.889289 
+L 144.889289 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_563">
+    <path d="M 157.406497 144.889289 
+L 157.406497 157.406497 
+L 144.889289 157.406497 
+L 144.889289 144.889289 
+L 157.406497 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_564">
+    <path d="M 157.406497 144.889289 
+L 157.406497 157.406497 
+L 144.889289 157.406497 
+L 144.889289 144.889289 
+L 157.406497 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_565">
+    <path d="M 169.923705 144.889289 
+L 169.923705 157.406497 
+L 157.406497 157.406497 
+L 157.406497 144.889289 
+L 169.923705 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_566">
+    <path d="M 169.923705 144.889289 
+L 169.923705 157.406497 
+L 157.406497 157.406497 
+L 157.406497 144.889289 
+L 169.923705 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_567">
+    <path d="M 182.440913 144.889289 
+L 182.440913 157.406497 
+L 169.923705 157.406497 
+L 169.923705 144.889289 
+L 182.440913 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_568">
+    <path d="M 182.440913 144.889289 
+L 182.440913 157.406497 
+L 169.923705 157.406497 
+L 169.923705 144.889289 
+L 182.440913 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_569">
+    <path d="M 194.958122 144.889289 
+L 194.958122 157.406497 
+L 182.440913 157.406497 
+L 182.440913 144.889289 
+L 194.958122 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_570">
+    <path d="M 194.958122 144.889289 
+L 194.958122 157.406497 
+L 182.440913 157.406497 
+L 182.440913 144.889289 
+L 194.958122 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_571">
+    <path d="M 207.47533 144.889289 
+L 207.47533 157.406497 
+L 194.958122 157.406497 
+L 194.958122 144.889289 
+L 207.47533 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_572">
+    <path d="M 207.47533 144.889289 
+L 207.47533 157.406497 
+L 194.958122 157.406497 
+L 194.958122 144.889289 
+L 207.47533 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_573">
+    <path d="M 219.992538 144.889289 
+L 219.992538 157.406497 
+L 207.47533 157.406497 
+L 207.47533 144.889289 
+L 219.992538 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_574">
+    <path d="M 219.992538 144.889289 
+L 219.992538 157.406497 
+L 207.47533 157.406497 
+L 207.47533 144.889289 
+L 219.992538 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_575">
+    <path d="M 232.509746 144.889289 
+L 232.509746 157.406497 
+L 219.992538 157.406497 
+L 219.992538 144.889289 
+L 232.509746 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_576">
+    <path d="M 232.509746 144.889289 
+L 232.509746 157.406497 
+L 219.992538 157.406497 
+L 219.992538 144.889289 
+L 232.509746 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_577">
+    <path d="M 245.026954 144.889289 
+L 245.026954 157.406497 
+L 232.509746 157.406497 
+L 232.509746 144.889289 
+L 245.026954 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_578">
+    <path d="M 245.026954 144.889289 
+L 245.026954 157.406497 
+L 232.509746 157.406497 
+L 232.509746 144.889289 
+L 245.026954 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_579">
+    <path d="M 257.544162 144.889289 
+L 257.544162 157.406497 
+L 245.026954 157.406497 
+L 245.026954 144.889289 
+L 257.544162 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_580">
+    <path d="M 257.544162 144.889289 
+L 257.544162 157.406497 
+L 245.026954 157.406497 
+L 245.026954 144.889289 
+L 257.544162 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_581">
+    <path d="M 270.06137 144.889289 
+L 270.06137 157.406497 
+L 257.544162 157.406497 
+L 257.544162 144.889289 
+L 270.06137 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_582">
+    <path d="M 270.06137 144.889289 
+L 270.06137 157.406497 
+L 257.544162 157.406497 
+L 257.544162 144.889289 
+L 270.06137 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_583">
+    <path d="M 282.578578 144.889289 
+L 282.578578 157.406497 
+L 270.06137 157.406497 
+L 270.06137 144.889289 
+L 282.578578 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_584">
+    <path d="M 282.578578 144.889289 
+L 282.578578 157.406497 
+L 270.06137 157.406497 
+L 270.06137 144.889289 
+L 282.578578 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_585">
+    <path d="M 295.095786 144.889289 
+L 295.095786 157.406497 
+L 282.578578 157.406497 
+L 282.578578 144.889289 
+L 295.095786 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_586">
+    <path d="M 295.095786 144.889289 
+L 295.095786 157.406497 
+L 282.578578 157.406497 
+L 282.578578 144.889289 
+L 295.095786 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_587">
+    <path d="M 307.612994 144.889289 
+L 307.612994 157.406497 
+L 295.095786 157.406497 
+L 295.095786 144.889289 
+L 307.612994 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_588">
+    <path d="M 307.612994 144.889289 
+L 307.612994 157.406497 
+L 295.095786 157.406497 
+L 295.095786 144.889289 
+L 307.612994 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_589">
+    <path d="M 320.130203 144.889289 
+L 320.130203 157.406497 
+L 307.612994 157.406497 
+L 307.612994 144.889289 
+L 320.130203 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_590">
+    <path d="M 320.130203 144.889289 
+L 320.130203 157.406497 
+L 307.612994 157.406497 
+L 307.612994 144.889289 
+L 320.130203 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_591">
+    <path d="M 332.647411 144.889289 
+L 332.647411 157.406497 
+L 320.130203 157.406497 
+L 320.130203 144.889289 
+L 332.647411 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_592">
+    <path d="M 332.647411 144.889289 
+L 332.647411 157.406497 
+L 320.130203 157.406497 
+L 320.130203 144.889289 
+L 332.647411 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_593">
+    <path d="M 345.164619 144.889289 
+L 345.164619 157.406497 
+L 332.647411 157.406497 
+L 332.647411 144.889289 
+L 345.164619 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_594">
+    <path d="M 345.164619 144.889289 
+L 345.164619 157.406497 
+L 332.647411 157.406497 
+L 332.647411 144.889289 
+L 345.164619 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_595">
+    <path d="M 357.681827 144.889289 
+L 357.681827 157.406497 
+L 345.164619 157.406497 
+L 345.164619 144.889289 
+L 357.681827 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_596">
+    <path d="M 357.681827 144.889289 
+L 357.681827 157.406497 
+L 345.164619 157.406497 
+L 345.164619 144.889289 
+L 357.681827 144.889289 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_597">
+    <path d="M 32.234416 157.406497 
+L 32.234416 169.923705 
+L 19.717208 169.923705 
+L 19.717208 157.406497 
+L 32.234416 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_598">
+    <path d="M 32.234416 157.406497 
+L 32.234416 169.923705 
+L 19.717208 169.923705 
+L 19.717208 157.406497 
+L 32.234416 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_599">
+    <path d="M 44.751624 157.406497 
+L 44.751624 169.923705 
+L 32.234416 169.923705 
+L 32.234416 157.406497 
+L 44.751624 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_600">
+    <path d="M 44.751624 157.406497 
+L 44.751624 169.923705 
+L 32.234416 169.923705 
+L 32.234416 157.406497 
+L 44.751624 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_601">
+    <path d="M 57.268832 157.406497 
+L 57.268832 169.923705 
+L 44.751624 169.923705 
+L 44.751624 157.406497 
+L 57.268832 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_602">
+    <path d="M 57.268832 157.406497 
+L 57.268832 169.923705 
+L 44.751624 169.923705 
+L 44.751624 157.406497 
+L 57.268832 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_603">
+    <path d="M 69.786041 157.406497 
+L 69.786041 169.923705 
+L 57.268832 169.923705 
+L 57.268832 157.406497 
+L 69.786041 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_604">
+    <path d="M 69.786041 157.406497 
+L 69.786041 169.923705 
+L 57.268832 169.923705 
+L 57.268832 157.406497 
+L 69.786041 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_605">
+    <path d="M 82.303249 157.406497 
+L 82.303249 169.923705 
+L 69.786041 169.923705 
+L 69.786041 157.406497 
+L 82.303249 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_606">
+    <path d="M 82.303249 157.406497 
+L 82.303249 169.923705 
+L 69.786041 169.923705 
+L 69.786041 157.406497 
+L 82.303249 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_607">
+    <path d="M 94.820457 157.406497 
+L 94.820457 169.923705 
+L 82.303249 169.923705 
+L 82.303249 157.406497 
+L 94.820457 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_608">
+    <path d="M 94.820457 157.406497 
+L 94.820457 169.923705 
+L 82.303249 169.923705 
+L 82.303249 157.406497 
+L 94.820457 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_609">
+    <path d="M 107.337665 157.406497 
+L 107.337665 169.923705 
+L 94.820457 169.923705 
+L 94.820457 157.406497 
+L 107.337665 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_610">
+    <path d="M 107.337665 157.406497 
+L 107.337665 169.923705 
+L 94.820457 169.923705 
+L 94.820457 157.406497 
+L 107.337665 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_611">
+    <path d="M 119.854873 157.406497 
+L 119.854873 169.923705 
+L 107.337665 169.923705 
+L 107.337665 157.406497 
+L 119.854873 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_612">
+    <path d="M 119.854873 157.406497 
+L 119.854873 169.923705 
+L 107.337665 169.923705 
+L 107.337665 157.406497 
+L 119.854873 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_613">
+    <path d="M 132.372081 157.406497 
+L 132.372081 169.923705 
+L 119.854873 169.923705 
+L 119.854873 157.406497 
+L 132.372081 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_614">
+    <path d="M 132.372081 157.406497 
+L 132.372081 169.923705 
+L 119.854873 169.923705 
+L 119.854873 157.406497 
+L 132.372081 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_615">
+    <path d="M 144.889289 157.406497 
+L 144.889289 169.923705 
+L 132.372081 169.923705 
+L 132.372081 157.406497 
+L 144.889289 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_616">
+    <path d="M 144.889289 157.406497 
+L 144.889289 169.923705 
+L 132.372081 169.923705 
+L 132.372081 157.406497 
+L 144.889289 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_617">
+    <path d="M 157.406497 157.406497 
+L 157.406497 169.923705 
+L 144.889289 169.923705 
+L 144.889289 157.406497 
+L 157.406497 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_618">
+    <path d="M 157.406497 157.406497 
+L 157.406497 169.923705 
+L 144.889289 169.923705 
+L 144.889289 157.406497 
+L 157.406497 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_619">
+    <path d="M 169.923705 157.406497 
+L 169.923705 169.923705 
+L 157.406497 169.923705 
+L 157.406497 157.406497 
+L 169.923705 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_620">
+    <path d="M 169.923705 157.406497 
+L 169.923705 169.923705 
+L 157.406497 169.923705 
+L 157.406497 157.406497 
+L 169.923705 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_621">
+    <path d="M 182.440913 157.406497 
+L 182.440913 169.923705 
+L 169.923705 169.923705 
+L 169.923705 157.406497 
+L 182.440913 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_622">
+    <path d="M 182.440913 157.406497 
+L 182.440913 169.923705 
+L 169.923705 169.923705 
+L 169.923705 157.406497 
+L 182.440913 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_623">
+    <path d="M 194.958122 157.406497 
+L 194.958122 169.923705 
+L 182.440913 169.923705 
+L 182.440913 157.406497 
+L 194.958122 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_624">
+    <path d="M 194.958122 157.406497 
+L 194.958122 169.923705 
+L 182.440913 169.923705 
+L 182.440913 157.406497 
+L 194.958122 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_625">
+    <path d="M 207.47533 157.406497 
+L 207.47533 169.923705 
+L 194.958122 169.923705 
+L 194.958122 157.406497 
+L 207.47533 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_626">
+    <path d="M 207.47533 157.406497 
+L 207.47533 169.923705 
+L 194.958122 169.923705 
+L 194.958122 157.406497 
+L 207.47533 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_627">
+    <path d="M 219.992538 157.406497 
+L 219.992538 169.923705 
+L 207.47533 169.923705 
+L 207.47533 157.406497 
+L 219.992538 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_628">
+    <path d="M 219.992538 157.406497 
+L 219.992538 169.923705 
+L 207.47533 169.923705 
+L 207.47533 157.406497 
+L 219.992538 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_629">
+    <path d="M 232.509746 157.406497 
+L 232.509746 169.923705 
+L 219.992538 169.923705 
+L 219.992538 157.406497 
+L 232.509746 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_630">
+    <path d="M 232.509746 157.406497 
+L 232.509746 169.923705 
+L 219.992538 169.923705 
+L 219.992538 157.406497 
+L 232.509746 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_631">
+    <path d="M 245.026954 157.406497 
+L 245.026954 169.923705 
+L 232.509746 169.923705 
+L 232.509746 157.406497 
+L 245.026954 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_632">
+    <path d="M 245.026954 157.406497 
+L 245.026954 169.923705 
+L 232.509746 169.923705 
+L 232.509746 157.406497 
+L 245.026954 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_633">
+    <path d="M 257.544162 157.406497 
+L 257.544162 169.923705 
+L 245.026954 169.923705 
+L 245.026954 157.406497 
+L 257.544162 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_634">
+    <path d="M 257.544162 157.406497 
+L 257.544162 169.923705 
+L 245.026954 169.923705 
+L 245.026954 157.406497 
+L 257.544162 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_635">
+    <path d="M 270.06137 157.406497 
+L 270.06137 169.923705 
+L 257.544162 169.923705 
+L 257.544162 157.406497 
+L 270.06137 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_636">
+    <path d="M 270.06137 157.406497 
+L 270.06137 169.923705 
+L 257.544162 169.923705 
+L 257.544162 157.406497 
+L 270.06137 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_637">
+    <path d="M 282.578578 157.406497 
+L 282.578578 169.923705 
+L 270.06137 169.923705 
+L 270.06137 157.406497 
+L 282.578578 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_638">
+    <path d="M 282.578578 157.406497 
+L 282.578578 169.923705 
+L 270.06137 169.923705 
+L 270.06137 157.406497 
+L 282.578578 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_639">
+    <path d="M 295.095786 157.406497 
+L 295.095786 169.923705 
+L 282.578578 169.923705 
+L 282.578578 157.406497 
+L 295.095786 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_640">
+    <path d="M 295.095786 157.406497 
+L 295.095786 169.923705 
+L 282.578578 169.923705 
+L 282.578578 157.406497 
+L 295.095786 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_641">
+    <path d="M 307.612994 157.406497 
+L 307.612994 169.923705 
+L 295.095786 169.923705 
+L 295.095786 157.406497 
+L 307.612994 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_642">
+    <path d="M 307.612994 157.406497 
+L 307.612994 169.923705 
+L 295.095786 169.923705 
+L 295.095786 157.406497 
+L 307.612994 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_643">
+    <path d="M 320.130203 157.406497 
+L 320.130203 169.923705 
+L 307.612994 169.923705 
+L 307.612994 157.406497 
+L 320.130203 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_644">
+    <path d="M 320.130203 157.406497 
+L 320.130203 169.923705 
+L 307.612994 169.923705 
+L 307.612994 157.406497 
+L 320.130203 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_645">
+    <path d="M 332.647411 157.406497 
+L 332.647411 169.923705 
+L 320.130203 169.923705 
+L 320.130203 157.406497 
+L 332.647411 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_646">
+    <path d="M 332.647411 157.406497 
+L 332.647411 169.923705 
+L 320.130203 169.923705 
+L 320.130203 157.406497 
+L 332.647411 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_647">
+    <path d="M 345.164619 157.406497 
+L 345.164619 169.923705 
+L 332.647411 169.923705 
+L 332.647411 157.406497 
+L 345.164619 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_648">
+    <path d="M 345.164619 157.406497 
+L 345.164619 169.923705 
+L 332.647411 169.923705 
+L 332.647411 157.406497 
+L 345.164619 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_649">
+    <path d="M 357.681827 157.406497 
+L 357.681827 169.923705 
+L 345.164619 169.923705 
+L 345.164619 157.406497 
+L 357.681827 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_650">
+    <path d="M 357.681827 157.406497 
+L 357.681827 169.923705 
+L 345.164619 169.923705 
+L 345.164619 157.406497 
+L 357.681827 157.406497 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_651">
+    <path d="M 32.234416 169.923705 
+L 32.234416 182.440913 
+L 19.717208 182.440913 
+L 19.717208 169.923705 
+L 32.234416 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_652">
+    <path d="M 32.234416 169.923705 
+L 32.234416 182.440913 
+L 19.717208 182.440913 
+L 19.717208 169.923705 
+L 32.234416 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_653">
+    <path d="M 44.751624 169.923705 
+L 44.751624 182.440913 
+L 32.234416 182.440913 
+L 32.234416 169.923705 
+L 44.751624 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_654">
+    <path d="M 44.751624 169.923705 
+L 44.751624 182.440913 
+L 32.234416 182.440913 
+L 32.234416 169.923705 
+L 44.751624 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_655">
+    <path d="M 57.268832 169.923705 
+L 57.268832 182.440913 
+L 44.751624 182.440913 
+L 44.751624 169.923705 
+L 57.268832 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_656">
+    <path d="M 57.268832 169.923705 
+L 57.268832 182.440913 
+L 44.751624 182.440913 
+L 44.751624 169.923705 
+L 57.268832 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_657">
+    <path d="M 69.786041 169.923705 
+L 69.786041 182.440913 
+L 57.268832 182.440913 
+L 57.268832 169.923705 
+L 69.786041 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_658">
+    <path d="M 69.786041 169.923705 
+L 69.786041 182.440913 
+L 57.268832 182.440913 
+L 57.268832 169.923705 
+L 69.786041 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_659">
+    <path d="M 82.303249 169.923705 
+L 82.303249 182.440913 
+L 69.786041 182.440913 
+L 69.786041 169.923705 
+L 82.303249 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_660">
+    <path d="M 82.303249 169.923705 
+L 82.303249 182.440913 
+L 69.786041 182.440913 
+L 69.786041 169.923705 
+L 82.303249 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_661">
+    <path d="M 94.820457 169.923705 
+L 94.820457 182.440913 
+L 82.303249 182.440913 
+L 82.303249 169.923705 
+L 94.820457 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_662">
+    <path d="M 94.820457 169.923705 
+L 94.820457 182.440913 
+L 82.303249 182.440913 
+L 82.303249 169.923705 
+L 94.820457 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_663">
+    <path d="M 107.337665 169.923705 
+L 107.337665 182.440913 
+L 94.820457 182.440913 
+L 94.820457 169.923705 
+L 107.337665 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_664">
+    <path d="M 107.337665 169.923705 
+L 107.337665 182.440913 
+L 94.820457 182.440913 
+L 94.820457 169.923705 
+L 107.337665 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_665">
+    <path d="M 119.854873 169.923705 
+L 119.854873 182.440913 
+L 107.337665 182.440913 
+L 107.337665 169.923705 
+L 119.854873 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_666">
+    <path d="M 119.854873 169.923705 
+L 119.854873 182.440913 
+L 107.337665 182.440913 
+L 107.337665 169.923705 
+L 119.854873 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_667">
+    <path d="M 132.372081 169.923705 
+L 132.372081 182.440913 
+L 119.854873 182.440913 
+L 119.854873 169.923705 
+L 132.372081 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_668">
+    <path d="M 132.372081 169.923705 
+L 132.372081 182.440913 
+L 119.854873 182.440913 
+L 119.854873 169.923705 
+L 132.372081 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_669">
+    <path d="M 144.889289 169.923705 
+L 144.889289 182.440913 
+L 132.372081 182.440913 
+L 132.372081 169.923705 
+L 144.889289 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_670">
+    <path d="M 144.889289 169.923705 
+L 144.889289 182.440913 
+L 132.372081 182.440913 
+L 132.372081 169.923705 
+L 144.889289 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_671">
+    <path d="M 157.406497 169.923705 
+L 157.406497 182.440913 
+L 144.889289 182.440913 
+L 144.889289 169.923705 
+L 157.406497 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_672">
+    <path d="M 157.406497 169.923705 
+L 157.406497 182.440913 
+L 144.889289 182.440913 
+L 144.889289 169.923705 
+L 157.406497 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_673">
+    <path d="M 169.923705 169.923705 
+L 169.923705 182.440913 
+L 157.406497 182.440913 
+L 157.406497 169.923705 
+L 169.923705 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_674">
+    <path d="M 169.923705 169.923705 
+L 169.923705 182.440913 
+L 157.406497 182.440913 
+L 157.406497 169.923705 
+L 169.923705 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_675">
+    <path d="M 182.440913 169.923705 
+L 182.440913 182.440913 
+L 169.923705 182.440913 
+L 169.923705 169.923705 
+L 182.440913 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_676">
+    <path d="M 182.440913 169.923705 
+L 182.440913 182.440913 
+L 169.923705 182.440913 
+L 169.923705 169.923705 
+L 182.440913 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_677">
+    <path d="M 194.958122 169.923705 
+L 194.958122 182.440913 
+L 182.440913 182.440913 
+L 182.440913 169.923705 
+L 194.958122 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_678">
+    <path d="M 194.958122 169.923705 
+L 194.958122 182.440913 
+L 182.440913 182.440913 
+L 182.440913 169.923705 
+L 194.958122 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_679">
+    <path d="M 207.47533 169.923705 
+L 207.47533 182.440913 
+L 194.958122 182.440913 
+L 194.958122 169.923705 
+L 207.47533 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_680">
+    <path d="M 207.47533 169.923705 
+L 207.47533 182.440913 
+L 194.958122 182.440913 
+L 194.958122 169.923705 
+L 207.47533 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_681">
+    <path d="M 219.992538 169.923705 
+L 219.992538 182.440913 
+L 207.47533 182.440913 
+L 207.47533 169.923705 
+L 219.992538 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_682">
+    <path d="M 219.992538 169.923705 
+L 219.992538 182.440913 
+L 207.47533 182.440913 
+L 207.47533 169.923705 
+L 219.992538 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_683">
+    <path d="M 232.509746 169.923705 
+L 232.509746 182.440913 
+L 219.992538 182.440913 
+L 219.992538 169.923705 
+L 232.509746 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_684">
+    <path d="M 232.509746 169.923705 
+L 232.509746 182.440913 
+L 219.992538 182.440913 
+L 219.992538 169.923705 
+L 232.509746 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_685">
+    <path d="M 245.026954 169.923705 
+L 245.026954 182.440913 
+L 232.509746 182.440913 
+L 232.509746 169.923705 
+L 245.026954 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_686">
+    <path d="M 245.026954 169.923705 
+L 245.026954 182.440913 
+L 232.509746 182.440913 
+L 232.509746 169.923705 
+L 245.026954 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_687">
+    <path d="M 257.544162 169.923705 
+L 257.544162 182.440913 
+L 245.026954 182.440913 
+L 245.026954 169.923705 
+L 257.544162 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_688">
+    <path d="M 257.544162 169.923705 
+L 257.544162 182.440913 
+L 245.026954 182.440913 
+L 245.026954 169.923705 
+L 257.544162 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_689">
+    <path d="M 270.06137 169.923705 
+L 270.06137 182.440913 
+L 257.544162 182.440913 
+L 257.544162 169.923705 
+L 270.06137 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_690">
+    <path d="M 270.06137 169.923705 
+L 270.06137 182.440913 
+L 257.544162 182.440913 
+L 257.544162 169.923705 
+L 270.06137 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_691">
+    <path d="M 282.578578 169.923705 
+L 282.578578 182.440913 
+L 270.06137 182.440913 
+L 270.06137 169.923705 
+L 282.578578 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_692">
+    <path d="M 282.578578 169.923705 
+L 282.578578 182.440913 
+L 270.06137 182.440913 
+L 270.06137 169.923705 
+L 282.578578 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_693">
+    <path d="M 295.095786 169.923705 
+L 295.095786 182.440913 
+L 282.578578 182.440913 
+L 282.578578 169.923705 
+L 295.095786 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_694">
+    <path d="M 295.095786 169.923705 
+L 295.095786 182.440913 
+L 282.578578 182.440913 
+L 282.578578 169.923705 
+L 295.095786 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_695">
+    <path d="M 307.612994 169.923705 
+L 307.612994 182.440913 
+L 295.095786 182.440913 
+L 295.095786 169.923705 
+L 307.612994 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_696">
+    <path d="M 307.612994 169.923705 
+L 307.612994 182.440913 
+L 295.095786 182.440913 
+L 295.095786 169.923705 
+L 307.612994 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_697">
+    <path d="M 320.130203 169.923705 
+L 320.130203 182.440913 
+L 307.612994 182.440913 
+L 307.612994 169.923705 
+L 320.130203 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_698">
+    <path d="M 320.130203 169.923705 
+L 320.130203 182.440913 
+L 307.612994 182.440913 
+L 307.612994 169.923705 
+L 320.130203 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_699">
+    <path d="M 332.647411 169.923705 
+L 332.647411 182.440913 
+L 320.130203 182.440913 
+L 320.130203 169.923705 
+L 332.647411 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_700">
+    <path d="M 332.647411 169.923705 
+L 332.647411 182.440913 
+L 320.130203 182.440913 
+L 320.130203 169.923705 
+L 332.647411 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_701">
+    <path d="M 345.164619 169.923705 
+L 345.164619 182.440913 
+L 332.647411 182.440913 
+L 332.647411 169.923705 
+L 345.164619 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_702">
+    <path d="M 345.164619 169.923705 
+L 345.164619 182.440913 
+L 332.647411 182.440913 
+L 332.647411 169.923705 
+L 345.164619 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_703">
+    <path d="M 357.681827 169.923705 
+L 357.681827 182.440913 
+L 345.164619 182.440913 
+L 345.164619 169.923705 
+L 357.681827 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_704">
+    <path d="M 357.681827 169.923705 
+L 357.681827 182.440913 
+L 345.164619 182.440913 
+L 345.164619 169.923705 
+L 357.681827 169.923705 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_705">
+    <path d="M 32.234416 182.440913 
+L 32.234416 194.958122 
+L 19.717208 194.958122 
+L 19.717208 182.440913 
+L 32.234416 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_706">
+    <path d="M 32.234416 182.440913 
+L 32.234416 194.958122 
+L 19.717208 194.958122 
+L 19.717208 182.440913 
+L 32.234416 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_707">
+    <path d="M 44.751624 182.440913 
+L 44.751624 194.958122 
+L 32.234416 194.958122 
+L 32.234416 182.440913 
+L 44.751624 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_708">
+    <path d="M 44.751624 182.440913 
+L 44.751624 194.958122 
+L 32.234416 194.958122 
+L 32.234416 182.440913 
+L 44.751624 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_709">
+    <path d="M 57.268832 182.440913 
+L 57.268832 194.958122 
+L 44.751624 194.958122 
+L 44.751624 182.440913 
+L 57.268832 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_710">
+    <path d="M 57.268832 182.440913 
+L 57.268832 194.958122 
+L 44.751624 194.958122 
+L 44.751624 182.440913 
+L 57.268832 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_711">
+    <path d="M 69.786041 182.440913 
+L 69.786041 194.958122 
+L 57.268832 194.958122 
+L 57.268832 182.440913 
+L 69.786041 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_712">
+    <path d="M 69.786041 182.440913 
+L 69.786041 194.958122 
+L 57.268832 194.958122 
+L 57.268832 182.440913 
+L 69.786041 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_713">
+    <path d="M 82.303249 182.440913 
+L 82.303249 194.958122 
+L 69.786041 194.958122 
+L 69.786041 182.440913 
+L 82.303249 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_714">
+    <path d="M 82.303249 182.440913 
+L 82.303249 194.958122 
+L 69.786041 194.958122 
+L 69.786041 182.440913 
+L 82.303249 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_715">
+    <path d="M 94.820457 182.440913 
+L 94.820457 194.958122 
+L 82.303249 194.958122 
+L 82.303249 182.440913 
+L 94.820457 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_716">
+    <path d="M 94.820457 182.440913 
+L 94.820457 194.958122 
+L 82.303249 194.958122 
+L 82.303249 182.440913 
+L 94.820457 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_717">
+    <path d="M 107.337665 182.440913 
+L 107.337665 194.958122 
+L 94.820457 194.958122 
+L 94.820457 182.440913 
+L 107.337665 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_718">
+    <path d="M 107.337665 182.440913 
+L 107.337665 194.958122 
+L 94.820457 194.958122 
+L 94.820457 182.440913 
+L 107.337665 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_719">
+    <path d="M 119.854873 182.440913 
+L 119.854873 194.958122 
+L 107.337665 194.958122 
+L 107.337665 182.440913 
+L 119.854873 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_720">
+    <path d="M 119.854873 182.440913 
+L 119.854873 194.958122 
+L 107.337665 194.958122 
+L 107.337665 182.440913 
+L 119.854873 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_721">
+    <path d="M 132.372081 182.440913 
+L 132.372081 194.958122 
+L 119.854873 194.958122 
+L 119.854873 182.440913 
+L 132.372081 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_722">
+    <path d="M 132.372081 182.440913 
+L 132.372081 194.958122 
+L 119.854873 194.958122 
+L 119.854873 182.440913 
+L 132.372081 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_723">
+    <path d="M 144.889289 182.440913 
+L 144.889289 194.958122 
+L 132.372081 194.958122 
+L 132.372081 182.440913 
+L 144.889289 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_724">
+    <path d="M 144.889289 182.440913 
+L 144.889289 194.958122 
+L 132.372081 194.958122 
+L 132.372081 182.440913 
+L 144.889289 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_725">
+    <path d="M 157.406497 182.440913 
+L 157.406497 194.958122 
+L 144.889289 194.958122 
+L 144.889289 182.440913 
+L 157.406497 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_726">
+    <path d="M 157.406497 182.440913 
+L 157.406497 194.958122 
+L 144.889289 194.958122 
+L 144.889289 182.440913 
+L 157.406497 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_727">
+    <path d="M 169.923705 182.440913 
+L 169.923705 194.958122 
+L 157.406497 194.958122 
+L 157.406497 182.440913 
+L 169.923705 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_728">
+    <path d="M 169.923705 182.440913 
+L 169.923705 194.958122 
+L 157.406497 194.958122 
+L 157.406497 182.440913 
+L 169.923705 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_729">
+    <path d="M 182.440913 182.440913 
+L 182.440913 194.958122 
+L 169.923705 194.958122 
+L 169.923705 182.440913 
+L 182.440913 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_730">
+    <path d="M 182.440913 182.440913 
+L 182.440913 194.958122 
+L 169.923705 194.958122 
+L 169.923705 182.440913 
+L 182.440913 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_731">
+    <path d="M 194.958122 182.440913 
+L 194.958122 194.958122 
+L 182.440913 194.958122 
+L 182.440913 182.440913 
+L 194.958122 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_732">
+    <path d="M 194.958122 182.440913 
+L 194.958122 194.958122 
+L 182.440913 194.958122 
+L 182.440913 182.440913 
+L 194.958122 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_733">
+    <path d="M 207.47533 182.440913 
+L 207.47533 194.958122 
+L 194.958122 194.958122 
+L 194.958122 182.440913 
+L 207.47533 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_734">
+    <path d="M 207.47533 182.440913 
+L 207.47533 194.958122 
+L 194.958122 194.958122 
+L 194.958122 182.440913 
+L 207.47533 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_735">
+    <path d="M 219.992538 182.440913 
+L 219.992538 194.958122 
+L 207.47533 194.958122 
+L 207.47533 182.440913 
+L 219.992538 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_736">
+    <path d="M 219.992538 182.440913 
+L 219.992538 194.958122 
+L 207.47533 194.958122 
+L 207.47533 182.440913 
+L 219.992538 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_737">
+    <path d="M 232.509746 182.440913 
+L 232.509746 194.958122 
+L 219.992538 194.958122 
+L 219.992538 182.440913 
+L 232.509746 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_738">
+    <path d="M 232.509746 182.440913 
+L 232.509746 194.958122 
+L 219.992538 194.958122 
+L 219.992538 182.440913 
+L 232.509746 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_739">
+    <path d="M 245.026954 182.440913 
+L 245.026954 194.958122 
+L 232.509746 194.958122 
+L 232.509746 182.440913 
+L 245.026954 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_740">
+    <path d="M 245.026954 182.440913 
+L 245.026954 194.958122 
+L 232.509746 194.958122 
+L 232.509746 182.440913 
+L 245.026954 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_741">
+    <path d="M 257.544162 182.440913 
+L 257.544162 194.958122 
+L 245.026954 194.958122 
+L 245.026954 182.440913 
+L 257.544162 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_742">
+    <path d="M 257.544162 182.440913 
+L 257.544162 194.958122 
+L 245.026954 194.958122 
+L 245.026954 182.440913 
+L 257.544162 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_743">
+    <path d="M 270.06137 182.440913 
+L 270.06137 194.958122 
+L 257.544162 194.958122 
+L 257.544162 182.440913 
+L 270.06137 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_744">
+    <path d="M 270.06137 182.440913 
+L 270.06137 194.958122 
+L 257.544162 194.958122 
+L 257.544162 182.440913 
+L 270.06137 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_745">
+    <path d="M 282.578578 182.440913 
+L 282.578578 194.958122 
+L 270.06137 194.958122 
+L 270.06137 182.440913 
+L 282.578578 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_746">
+    <path d="M 282.578578 182.440913 
+L 282.578578 194.958122 
+L 270.06137 194.958122 
+L 270.06137 182.440913 
+L 282.578578 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_747">
+    <path d="M 295.095786 182.440913 
+L 295.095786 194.958122 
+L 282.578578 194.958122 
+L 282.578578 182.440913 
+L 295.095786 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_748">
+    <path d="M 295.095786 182.440913 
+L 295.095786 194.958122 
+L 282.578578 194.958122 
+L 282.578578 182.440913 
+L 295.095786 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_749">
+    <path d="M 307.612994 182.440913 
+L 307.612994 194.958122 
+L 295.095786 194.958122 
+L 295.095786 182.440913 
+L 307.612994 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_750">
+    <path d="M 307.612994 182.440913 
+L 307.612994 194.958122 
+L 295.095786 194.958122 
+L 295.095786 182.440913 
+L 307.612994 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_751">
+    <path d="M 320.130203 182.440913 
+L 320.130203 194.958122 
+L 307.612994 194.958122 
+L 307.612994 182.440913 
+L 320.130203 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_752">
+    <path d="M 320.130203 182.440913 
+L 320.130203 194.958122 
+L 307.612994 194.958122 
+L 307.612994 182.440913 
+L 320.130203 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_753">
+    <path d="M 332.647411 182.440913 
+L 332.647411 194.958122 
+L 320.130203 194.958122 
+L 320.130203 182.440913 
+L 332.647411 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_754">
+    <path d="M 332.647411 182.440913 
+L 332.647411 194.958122 
+L 320.130203 194.958122 
+L 320.130203 182.440913 
+L 332.647411 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_755">
+    <path d="M 345.164619 182.440913 
+L 345.164619 194.958122 
+L 332.647411 194.958122 
+L 332.647411 182.440913 
+L 345.164619 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_756">
+    <path d="M 345.164619 182.440913 
+L 345.164619 194.958122 
+L 332.647411 194.958122 
+L 332.647411 182.440913 
+L 345.164619 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_757">
+    <path d="M 357.681827 182.440913 
+L 357.681827 194.958122 
+L 345.164619 194.958122 
+L 345.164619 182.440913 
+L 357.681827 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_758">
+    <path d="M 357.681827 182.440913 
+L 357.681827 194.958122 
+L 345.164619 194.958122 
+L 345.164619 182.440913 
+L 357.681827 182.440913 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_759">
+    <path d="M 32.234416 194.958122 
+L 32.234416 207.47533 
+L 19.717208 207.47533 
+L 19.717208 194.958122 
+L 32.234416 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_760">
+    <path d="M 32.234416 194.958122 
+L 32.234416 207.47533 
+L 19.717208 207.47533 
+L 19.717208 194.958122 
+L 32.234416 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_761">
+    <path d="M 44.751624 194.958122 
+L 44.751624 207.47533 
+L 32.234416 207.47533 
+L 32.234416 194.958122 
+L 44.751624 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_762">
+    <path d="M 44.751624 194.958122 
+L 44.751624 207.47533 
+L 32.234416 207.47533 
+L 32.234416 194.958122 
+L 44.751624 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_763">
+    <path d="M 57.268832 194.958122 
+L 57.268832 207.47533 
+L 44.751624 207.47533 
+L 44.751624 194.958122 
+L 57.268832 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_764">
+    <path d="M 57.268832 194.958122 
+L 57.268832 207.47533 
+L 44.751624 207.47533 
+L 44.751624 194.958122 
+L 57.268832 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_765">
+    <path d="M 69.786041 194.958122 
+L 69.786041 207.47533 
+L 57.268832 207.47533 
+L 57.268832 194.958122 
+L 69.786041 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_766">
+    <path d="M 69.786041 194.958122 
+L 69.786041 207.47533 
+L 57.268832 207.47533 
+L 57.268832 194.958122 
+L 69.786041 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_767">
+    <path d="M 82.303249 194.958122 
+L 82.303249 207.47533 
+L 69.786041 207.47533 
+L 69.786041 194.958122 
+L 82.303249 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_768">
+    <path d="M 82.303249 194.958122 
+L 82.303249 207.47533 
+L 69.786041 207.47533 
+L 69.786041 194.958122 
+L 82.303249 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_769">
+    <path d="M 94.820457 194.958122 
+L 94.820457 207.47533 
+L 82.303249 207.47533 
+L 82.303249 194.958122 
+L 94.820457 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_770">
+    <path d="M 94.820457 194.958122 
+L 94.820457 207.47533 
+L 82.303249 207.47533 
+L 82.303249 194.958122 
+L 94.820457 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_771">
+    <path d="M 107.337665 194.958122 
+L 107.337665 207.47533 
+L 94.820457 207.47533 
+L 94.820457 194.958122 
+L 107.337665 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_772">
+    <path d="M 107.337665 194.958122 
+L 107.337665 207.47533 
+L 94.820457 207.47533 
+L 94.820457 194.958122 
+L 107.337665 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_773">
+    <path d="M 119.854873 194.958122 
+L 119.854873 207.47533 
+L 107.337665 207.47533 
+L 107.337665 194.958122 
+L 119.854873 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_774">
+    <path d="M 119.854873 194.958122 
+L 119.854873 207.47533 
+L 107.337665 207.47533 
+L 107.337665 194.958122 
+L 119.854873 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_775">
+    <path d="M 132.372081 194.958122 
+L 132.372081 207.47533 
+L 119.854873 207.47533 
+L 119.854873 194.958122 
+L 132.372081 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_776">
+    <path d="M 132.372081 194.958122 
+L 132.372081 207.47533 
+L 119.854873 207.47533 
+L 119.854873 194.958122 
+L 132.372081 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_777">
+    <path d="M 144.889289 194.958122 
+L 144.889289 207.47533 
+L 132.372081 207.47533 
+L 132.372081 194.958122 
+L 144.889289 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_778">
+    <path d="M 144.889289 194.958122 
+L 144.889289 207.47533 
+L 132.372081 207.47533 
+L 132.372081 194.958122 
+L 144.889289 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_779">
+    <path d="M 157.406497 194.958122 
+L 157.406497 207.47533 
+L 144.889289 207.47533 
+L 144.889289 194.958122 
+L 157.406497 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_780">
+    <path d="M 157.406497 194.958122 
+L 157.406497 207.47533 
+L 144.889289 207.47533 
+L 144.889289 194.958122 
+L 157.406497 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_781">
+    <path d="M 169.923705 194.958122 
+L 169.923705 207.47533 
+L 157.406497 207.47533 
+L 157.406497 194.958122 
+L 169.923705 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_782">
+    <path d="M 169.923705 194.958122 
+L 169.923705 207.47533 
+L 157.406497 207.47533 
+L 157.406497 194.958122 
+L 169.923705 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_783">
+    <path d="M 182.440913 194.958122 
+L 182.440913 207.47533 
+L 169.923705 207.47533 
+L 169.923705 194.958122 
+L 182.440913 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_784">
+    <path d="M 182.440913 194.958122 
+L 182.440913 207.47533 
+L 169.923705 207.47533 
+L 169.923705 194.958122 
+L 182.440913 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_785">
+    <path d="M 194.958122 194.958122 
+L 194.958122 207.47533 
+L 182.440913 207.47533 
+L 182.440913 194.958122 
+L 194.958122 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_786">
+    <path d="M 194.958122 194.958122 
+L 194.958122 207.47533 
+L 182.440913 207.47533 
+L 182.440913 194.958122 
+L 194.958122 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_787">
+    <path d="M 207.47533 194.958122 
+L 207.47533 207.47533 
+L 194.958122 207.47533 
+L 194.958122 194.958122 
+L 207.47533 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_788">
+    <path d="M 207.47533 194.958122 
+L 207.47533 207.47533 
+L 194.958122 207.47533 
+L 194.958122 194.958122 
+L 207.47533 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_789">
+    <path d="M 219.992538 194.958122 
+L 219.992538 207.47533 
+L 207.47533 207.47533 
+L 207.47533 194.958122 
+L 219.992538 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_790">
+    <path d="M 219.992538 194.958122 
+L 219.992538 207.47533 
+L 207.47533 207.47533 
+L 207.47533 194.958122 
+L 219.992538 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_791">
+    <path d="M 232.509746 194.958122 
+L 232.509746 207.47533 
+L 219.992538 207.47533 
+L 219.992538 194.958122 
+L 232.509746 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_792">
+    <path d="M 232.509746 194.958122 
+L 232.509746 207.47533 
+L 219.992538 207.47533 
+L 219.992538 194.958122 
+L 232.509746 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_793">
+    <path d="M 245.026954 194.958122 
+L 245.026954 207.47533 
+L 232.509746 207.47533 
+L 232.509746 194.958122 
+L 245.026954 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_794">
+    <path d="M 245.026954 194.958122 
+L 245.026954 207.47533 
+L 232.509746 207.47533 
+L 232.509746 194.958122 
+L 245.026954 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_795">
+    <path d="M 257.544162 194.958122 
+L 257.544162 207.47533 
+L 245.026954 207.47533 
+L 245.026954 194.958122 
+L 257.544162 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_796">
+    <path d="M 257.544162 194.958122 
+L 257.544162 207.47533 
+L 245.026954 207.47533 
+L 245.026954 194.958122 
+L 257.544162 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_797">
+    <path d="M 270.06137 194.958122 
+L 270.06137 207.47533 
+L 257.544162 207.47533 
+L 257.544162 194.958122 
+L 270.06137 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_798">
+    <path d="M 270.06137 194.958122 
+L 270.06137 207.47533 
+L 257.544162 207.47533 
+L 257.544162 194.958122 
+L 270.06137 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_799">
+    <path d="M 282.578578 194.958122 
+L 282.578578 207.47533 
+L 270.06137 207.47533 
+L 270.06137 194.958122 
+L 282.578578 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_800">
+    <path d="M 282.578578 194.958122 
+L 282.578578 207.47533 
+L 270.06137 207.47533 
+L 270.06137 194.958122 
+L 282.578578 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_801">
+    <path d="M 295.095786 194.958122 
+L 295.095786 207.47533 
+L 282.578578 207.47533 
+L 282.578578 194.958122 
+L 295.095786 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_802">
+    <path d="M 295.095786 194.958122 
+L 295.095786 207.47533 
+L 282.578578 207.47533 
+L 282.578578 194.958122 
+L 295.095786 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_803">
+    <path d="M 307.612994 194.958122 
+L 307.612994 207.47533 
+L 295.095786 207.47533 
+L 295.095786 194.958122 
+L 307.612994 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_804">
+    <path d="M 307.612994 194.958122 
+L 307.612994 207.47533 
+L 295.095786 207.47533 
+L 295.095786 194.958122 
+L 307.612994 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_805">
+    <path d="M 320.130203 194.958122 
+L 320.130203 207.47533 
+L 307.612994 207.47533 
+L 307.612994 194.958122 
+L 320.130203 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_806">
+    <path d="M 320.130203 194.958122 
+L 320.130203 207.47533 
+L 307.612994 207.47533 
+L 307.612994 194.958122 
+L 320.130203 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_807">
+    <path d="M 332.647411 194.958122 
+L 332.647411 207.47533 
+L 320.130203 207.47533 
+L 320.130203 194.958122 
+L 332.647411 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_808">
+    <path d="M 332.647411 194.958122 
+L 332.647411 207.47533 
+L 320.130203 207.47533 
+L 320.130203 194.958122 
+L 332.647411 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_809">
+    <path d="M 345.164619 194.958122 
+L 345.164619 207.47533 
+L 332.647411 207.47533 
+L 332.647411 194.958122 
+L 345.164619 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_810">
+    <path d="M 345.164619 194.958122 
+L 345.164619 207.47533 
+L 332.647411 207.47533 
+L 332.647411 194.958122 
+L 345.164619 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_811">
+    <path d="M 357.681827 194.958122 
+L 357.681827 207.47533 
+L 345.164619 207.47533 
+L 345.164619 194.958122 
+L 357.681827 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_812">
+    <path d="M 357.681827 194.958122 
+L 357.681827 207.47533 
+L 345.164619 207.47533 
+L 345.164619 194.958122 
+L 357.681827 194.958122 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_813">
+    <path d="M 32.234416 207.47533 
+L 32.234416 219.992538 
+L 19.717208 219.992538 
+L 19.717208 207.47533 
+L 32.234416 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_814">
+    <path d="M 32.234416 207.47533 
+L 32.234416 219.992538 
+L 19.717208 219.992538 
+L 19.717208 207.47533 
+L 32.234416 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_815">
+    <path d="M 44.751624 207.47533 
+L 44.751624 219.992538 
+L 32.234416 219.992538 
+L 32.234416 207.47533 
+L 44.751624 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_816">
+    <path d="M 44.751624 207.47533 
+L 44.751624 219.992538 
+L 32.234416 219.992538 
+L 32.234416 207.47533 
+L 44.751624 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_817">
+    <path d="M 57.268832 207.47533 
+L 57.268832 219.992538 
+L 44.751624 219.992538 
+L 44.751624 207.47533 
+L 57.268832 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_818">
+    <path d="M 57.268832 207.47533 
+L 57.268832 219.992538 
+L 44.751624 219.992538 
+L 44.751624 207.47533 
+L 57.268832 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_819">
+    <path d="M 69.786041 207.47533 
+L 69.786041 219.992538 
+L 57.268832 219.992538 
+L 57.268832 207.47533 
+L 69.786041 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_820">
+    <path d="M 69.786041 207.47533 
+L 69.786041 219.992538 
+L 57.268832 219.992538 
+L 57.268832 207.47533 
+L 69.786041 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_821">
+    <path d="M 82.303249 207.47533 
+L 82.303249 219.992538 
+L 69.786041 219.992538 
+L 69.786041 207.47533 
+L 82.303249 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_822">
+    <path d="M 82.303249 207.47533 
+L 82.303249 219.992538 
+L 69.786041 219.992538 
+L 69.786041 207.47533 
+L 82.303249 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_823">
+    <path d="M 94.820457 207.47533 
+L 94.820457 219.992538 
+L 82.303249 219.992538 
+L 82.303249 207.47533 
+L 94.820457 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_824">
+    <path d="M 94.820457 207.47533 
+L 94.820457 219.992538 
+L 82.303249 219.992538 
+L 82.303249 207.47533 
+L 94.820457 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_825">
+    <path d="M 107.337665 207.47533 
+L 107.337665 219.992538 
+L 94.820457 219.992538 
+L 94.820457 207.47533 
+L 107.337665 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_826">
+    <path d="M 107.337665 207.47533 
+L 107.337665 219.992538 
+L 94.820457 219.992538 
+L 94.820457 207.47533 
+L 107.337665 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_827">
+    <path d="M 119.854873 207.47533 
+L 119.854873 219.992538 
+L 107.337665 219.992538 
+L 107.337665 207.47533 
+L 119.854873 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_828">
+    <path d="M 119.854873 207.47533 
+L 119.854873 219.992538 
+L 107.337665 219.992538 
+L 107.337665 207.47533 
+L 119.854873 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_829">
+    <path d="M 132.372081 207.47533 
+L 132.372081 219.992538 
+L 119.854873 219.992538 
+L 119.854873 207.47533 
+L 132.372081 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_830">
+    <path d="M 132.372081 207.47533 
+L 132.372081 219.992538 
+L 119.854873 219.992538 
+L 119.854873 207.47533 
+L 132.372081 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_831">
+    <path d="M 144.889289 207.47533 
+L 144.889289 219.992538 
+L 132.372081 219.992538 
+L 132.372081 207.47533 
+L 144.889289 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_832">
+    <path d="M 144.889289 207.47533 
+L 144.889289 219.992538 
+L 132.372081 219.992538 
+L 132.372081 207.47533 
+L 144.889289 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_833">
+    <path d="M 157.406497 207.47533 
+L 157.406497 219.992538 
+L 144.889289 219.992538 
+L 144.889289 207.47533 
+L 157.406497 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_834">
+    <path d="M 157.406497 207.47533 
+L 157.406497 219.992538 
+L 144.889289 219.992538 
+L 144.889289 207.47533 
+L 157.406497 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_835">
+    <path d="M 169.923705 207.47533 
+L 169.923705 219.992538 
+L 157.406497 219.992538 
+L 157.406497 207.47533 
+L 169.923705 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_836">
+    <path d="M 169.923705 207.47533 
+L 169.923705 219.992538 
+L 157.406497 219.992538 
+L 157.406497 207.47533 
+L 169.923705 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_837">
+    <path d="M 182.440913 207.47533 
+L 182.440913 219.992538 
+L 169.923705 219.992538 
+L 169.923705 207.47533 
+L 182.440913 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_838">
+    <path d="M 182.440913 207.47533 
+L 182.440913 219.992538 
+L 169.923705 219.992538 
+L 169.923705 207.47533 
+L 182.440913 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_839">
+    <path d="M 194.958122 207.47533 
+L 194.958122 219.992538 
+L 182.440913 219.992538 
+L 182.440913 207.47533 
+L 194.958122 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_840">
+    <path d="M 194.958122 207.47533 
+L 194.958122 219.992538 
+L 182.440913 219.992538 
+L 182.440913 207.47533 
+L 194.958122 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_841">
+    <path d="M 207.47533 207.47533 
+L 207.47533 219.992538 
+L 194.958122 219.992538 
+L 194.958122 207.47533 
+L 207.47533 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_842">
+    <path d="M 207.47533 207.47533 
+L 207.47533 219.992538 
+L 194.958122 219.992538 
+L 194.958122 207.47533 
+L 207.47533 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_843">
+    <path d="M 219.992538 207.47533 
+L 219.992538 219.992538 
+L 207.47533 219.992538 
+L 207.47533 207.47533 
+L 219.992538 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_844">
+    <path d="M 219.992538 207.47533 
+L 219.992538 219.992538 
+L 207.47533 219.992538 
+L 207.47533 207.47533 
+L 219.992538 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_845">
+    <path d="M 232.509746 207.47533 
+L 232.509746 219.992538 
+L 219.992538 219.992538 
+L 219.992538 207.47533 
+L 232.509746 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_846">
+    <path d="M 232.509746 207.47533 
+L 232.509746 219.992538 
+L 219.992538 219.992538 
+L 219.992538 207.47533 
+L 232.509746 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_847">
+    <path d="M 245.026954 207.47533 
+L 245.026954 219.992538 
+L 232.509746 219.992538 
+L 232.509746 207.47533 
+L 245.026954 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_848">
+    <path d="M 245.026954 207.47533 
+L 245.026954 219.992538 
+L 232.509746 219.992538 
+L 232.509746 207.47533 
+L 245.026954 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_849">
+    <path d="M 257.544162 207.47533 
+L 257.544162 219.992538 
+L 245.026954 219.992538 
+L 245.026954 207.47533 
+L 257.544162 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_850">
+    <path d="M 257.544162 207.47533 
+L 257.544162 219.992538 
+L 245.026954 219.992538 
+L 245.026954 207.47533 
+L 257.544162 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_851">
+    <path d="M 270.06137 207.47533 
+L 270.06137 219.992538 
+L 257.544162 219.992538 
+L 257.544162 207.47533 
+L 270.06137 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_852">
+    <path d="M 270.06137 207.47533 
+L 270.06137 219.992538 
+L 257.544162 219.992538 
+L 257.544162 207.47533 
+L 270.06137 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_853">
+    <path d="M 282.578578 207.47533 
+L 282.578578 219.992538 
+L 270.06137 219.992538 
+L 270.06137 207.47533 
+L 282.578578 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_854">
+    <path d="M 282.578578 207.47533 
+L 282.578578 219.992538 
+L 270.06137 219.992538 
+L 270.06137 207.47533 
+L 282.578578 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_855">
+    <path d="M 295.095786 207.47533 
+L 295.095786 219.992538 
+L 282.578578 219.992538 
+L 282.578578 207.47533 
+L 295.095786 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_856">
+    <path d="M 295.095786 207.47533 
+L 295.095786 219.992538 
+L 282.578578 219.992538 
+L 282.578578 207.47533 
+L 295.095786 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_857">
+    <path d="M 307.612994 207.47533 
+L 307.612994 219.992538 
+L 295.095786 219.992538 
+L 295.095786 207.47533 
+L 307.612994 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_858">
+    <path d="M 307.612994 207.47533 
+L 307.612994 219.992538 
+L 295.095786 219.992538 
+L 295.095786 207.47533 
+L 307.612994 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_859">
+    <path d="M 320.130203 207.47533 
+L 320.130203 219.992538 
+L 307.612994 219.992538 
+L 307.612994 207.47533 
+L 320.130203 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_860">
+    <path d="M 320.130203 207.47533 
+L 320.130203 219.992538 
+L 307.612994 219.992538 
+L 307.612994 207.47533 
+L 320.130203 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_861">
+    <path d="M 332.647411 207.47533 
+L 332.647411 219.992538 
+L 320.130203 219.992538 
+L 320.130203 207.47533 
+L 332.647411 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_862">
+    <path d="M 332.647411 207.47533 
+L 332.647411 219.992538 
+L 320.130203 219.992538 
+L 320.130203 207.47533 
+L 332.647411 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_863">
+    <path d="M 345.164619 207.47533 
+L 345.164619 219.992538 
+L 332.647411 219.992538 
+L 332.647411 207.47533 
+L 345.164619 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_864">
+    <path d="M 345.164619 207.47533 
+L 345.164619 219.992538 
+L 332.647411 219.992538 
+L 332.647411 207.47533 
+L 345.164619 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+   <g id="patch_865">
+    <path d="M 357.681827 207.47533 
+L 357.681827 219.992538 
+L 345.164619 219.992538 
+L 345.164619 207.47533 
+L 357.681827 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; stroke: #727d8b; stroke-width: 0.1; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_866">
+    <path d="M 357.681827 207.47533 
+L 357.681827 219.992538 
+L 345.164619 219.992538 
+L 345.164619 207.47533 
+L 357.681827 207.47533 
+z
+" clip-path="url(#p9ee2866781)" style="fill: none; opacity: 0"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p9ee2866781">
+   <rect x="7.2" y="7.2" width="357.12" height="214.971655"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/source/readthedocs.ipynb
+++ b/docs/source/readthedocs.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -17,12 +17,12 @@
     "from numpy.random import randint\n",
     "from shapely import MultiPoint, Point, Polygon\n",
     "from shapely.ops import voronoi_diagram\n",
-    "from sklearn.preprocessing import MinMaxScaler"
+    "# from sklearn.preprocessing import MinMaxScaler"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -1215,7 +1215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -1236,16 +1236,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgMAAAEkCAYAAACymjJEAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAACwZJREFUeJzt3bFrX+Uex/EnJmn5VSoWUaHcQcSlgoPgf1DocNc7FEuLo45WsELBtWAddKyjRMQid/QOhf4buogWmv5oUjSloQ03iZ47eJ1zcvidnOfJ5/Wav8Q3LvnQlucsdV3XFQAg1nNTBwAA0zIGACCcMQAA4YwBAAhnDABAOGMAAMIZAwAQzhgAgHDGAACEMwYAIJwxAADhjAEACGcMAEA4YwAAwhkDABDOGACAcMYAAIQzBgAgnDEAAOGMAQAItzJ1QCmlbD1+Up4+25k6AwAm8fypWTnz4guT/fcnHwNbj5+Uz778quz9uTR1CgBMYvW5rnzy4fuTDYLJx8DTZztl78+lculf/yyvvvzSgffzO9fL2Qs3ev3ssW5r6WixuZYOzVkdmrM6WmveePRb+fbf/ylPn+3kjoG/vfryS+UfZ1898G5/ttPrbszbWjpabK6lQ3NWh+asjhabp+YfEAJAOGMAAMIZAwAQzhgAgHDGAACEMwYAIJwxAADhjAEACLfUdV03ZcD6fKN8cWutXHz9p/LK7ODvE/zx3ydl+WS/F5rGuq2lo8XmWjo0Z3VozuporXlzZ1Zu/3KuXP3gynSPFHUTu//gYffRp5939x887HX/63fv9v7ZY93W0tFicy0dmrM6NGd1tNZ82N+DY/DXBAAQzhgAgHDGAACEMwYAIJwxAADhjAEACGcMAEA4YwAAwq1MHTCm7d3Vsj7f6HW7uTMrKz1vD3tfw62O4be1dLTYXEuH5qyOMZu3d1d7/9yWHNvniLd3V8vS2x8vqBIASln7/ody+Y0fy+kTewfetvQccTV/MnD2wo1e/xPu3b5UXrv47YF36/ON8vj3RwuqA4BS9rvlcub8zYX+vlqZb5Rya21BhcP4NwMAEM4YAIBwxgAAhDMGACCcMQAA4YwBAAhnDABAOGMAAMIZAwAQrpoXCOd3rpf9ns8R37t96cC7zZ1ZOfXO1QXVAcBfxvh9Vcq5BdUNU80YWPRzxCueIwZgBGP8vvIcMQAwKWMAAMIZAwAQzhgAgHDGAACEMwYAIJwxAADhjAEACGcMAEA4YwAAwlXzHLFvEwDQAt8mGJFvEwDQAt8mAACOHWMAAMIZAwAQzhgAgHDGAACEMwYAIJwxAADhjAEACGcMAEC4al4g9BwxAC3wHPGIPEcMQAs8RwwAHDvGAACEMwYAIJwxAADhjAEACGcMAEA4YwAAwhkDABDOGACAcNW8QLjo5x23d1fLNz+/Wfa75QUVApBuZemPsnX3Wtk/sXfgreeIB1j0846llHJ57b1y5vzNXrfzO9fL2Qs3et0e9r6GWx3Db2vpaLG5lg7NWR1jNm/dvVbeuvJ1r9uWniOuZgyM4fSJvV4Do5RS9mc7vW8Pe1/DrY7ht7V0tNhcS4fmrI5Rm3v8iUCL/JsBAAhnDABAOGMAAMIZAwAQzhgAgHDGAACEMwYAIJwxAADhjAEACLfUdV03ZcD6fKN8cWutXHz9p/JKz28TLJ98odfPHuu2lo4Wm2vp0JzVoTmro7XmzZ1Zuf3LuXL1gyuHejlxobqJ3X/wsPvo08+7+w8e9rr/9bt3e//ssW5r6WixuZYOzVkdmrM6Wms+7O/BMfhrAgAIZwwAQDhjAADCGQMAEM4YAIBwxgAAhDMGACCcMQAA4YwBAAjnOeIBt7V0tNhcS4fmrA7NWR2tNXuO2HPER3arY/htLR0tNtfSoTmro7VmzxEDAJMzBgAgnDEAAOGMAQAIZwwAQDhjAADCGQMAEM4YAIBwxgAAhPMc8YDbWjpabK6lQ3NWh+asjtaaPUfsOeIju9Ux/LaWjhaba+nQnNXRWrPniAGAyRkDABDOGACAcMYAAIQzBgAgnDEAAOGMAQAIZwwAQDhjAADCeY54wG0tHS0219KhOatDc1ZHa82eI/Yc8ZHd6hh+W0tHi821dGjO6mit2XPEAMDkjAEACGcMAEA4YwAAwhkDABDOGACAcMYAAIQzBgAgnDEAAOGMAQAI59sEA25r6WixuZYOzVkdmrM6Wmv2bQLfJjiyWx3Db2vpaLG5lg7NWR2tNfs2AQAwOWMAAMIZAwAQzhgAgHDGAACEMwYAIJwxAADhjAEACGcMAEA4zxEPuK2lo8XmWjo0Z3VozupordlzxJ4jPrJbHcNva+losbmWDs1ZHa01e44YAJicMQAA4YwBAAhnDABAOGMAAMIZAwAQzhgAgHDGAACEMwYAIJzniAfc1tLRYnMtHZqzOjRndbTW7DlizxEf2a2O4be1dLTYXEuH5qyO1po9RwwATM4YAIBwxgAAhDMGACCcMQAA4YwBAAhnDABAOGMAAMIZAwAQznPEA25r6WixuZYOzVkdmrM6Wmv2HLHniI/sVsfw21o6WmyupUNzVkdrzZ4jBgAmZwwAQDhjAADCGQMAEM4YAIBwxgAAhDMGACCcMQAA4YwBAAhnDABAON8mGHBbS0eLzbV0aM7q0JzV0VqzbxP4NsGR3eoYfltLR4vNtXRozupordm3CQCAyRkDABDOGACAcMYAAIQzBgAgnDEAAOGMAQAIZwwAQLiVqQPGtL27WtbnG71uN3dmZaXn7WHva7jVMfy2lo4Wm2vp0JzVMWbz9u5q75/bkmP7HPH27mpZevvjBVUCQClr3/9QLr/xYzl9Yu/A25aeI67mTwbOXrjR63/CvduXymsXvz3wbn2+UR7//mhBdQBQyn63XM6cv7nQ31cr841Sbq0tqHAY/2YAAMIZAwAQzhgAgHDGAACEMwYAIJwxAADhjAEACGcMAEA4YwAAwlXzAuH8zvWy3/M54nu3Lx14t7kzK6feubqgOgD4yxi/r0o5t6C6YaoZA4t+jnjFc8QAjGCM31eeIwYAJmUMAEA4YwAAwhkDABDOGACAcMYAAIQzBgAgnDEAAOGMAQAIZwwAQLhqniP2bQIAWuDbBCPybQIAWuDbBADAsWMMAEA4YwAAwhkDABDOGACAcMYAAIQzBgAgnDEAAOGMAQAIV80LhJ4jBqAFniMekeeIAWiB54gBgGPHGACAcMYAAIQzBgAgnDEAAOGMAQAIZwwAQDhjAADCGQMAEK6aFwgX/bzj9u5q+ebnN8t+t7ygQgDSrSz9UbbuXiv7J/YOvPUc8QCLft6xlFIur71Xzpy/2et2fud6OXvhRq/bw97XcKtj+G0tHS0219KhOatjzOatu9fKW1e+7nXb0nPE1YyBMZw+sddrYJRSyv5sp/ftYe9ruNUx/LaWjhaba+nQnNUxanOPPxFokX8zAADhjAEACGcMAEA4YwAAwhkDABDOGACAcMYAAIQzBgAg3FLXdd2UAevzjfLFrbVy8fWfyis9nyNePvlCr5891m0tHS0219KhOatDc1ZHa82bO7Ny+5dz5eoHVw71WNJCdRO7/+Bh99Gnn3f3Hzzsdf/rd+/2/tlj3dbS0WJzLR2aszo0Z3W01nzY34Nj8NcEABDOGACAcMYAAIQzBgAgnDEAAOGMAQAIZwwAQDhjAADCGQMAEG5l6oC/bTz6rdfd5s6srMw3Jr2tpaPF5lo6NGd1aM7qaK257++/MU3+bYKtx0/KZ19+Vfb+XJoyAwAms/pcVz758P1y5sX+31RYpMnHQPn/IHj67OCPFAHAcfT8qdlkQ6DUMgYAgOn4B4QAEM4YAIBwxgAAhDMGACCcMQAA4YwBAAhnDABAOGMAAMIZAwAQzhgAgHDGAACEMwYAIJwxAADhjAEACGcMAEA4YwAAwhkDABDOGACAcMYAAIT7H/Mqptfsu8+4AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from pedpy import MeasurementArea, plot_measurement_setup\n",
-    "from pedpy.methods.profile_calculator import _get_grid_cells\n",
+    "from pedpy.methods.profile_calculator import get_grid_cells\n",
     "\n",
-    "cells = _get_grid_cells(walkable_area=walkable_area, grid_size=0.5)\n",
+    "cells = get_grid_cells(walkable_area=walkable_area, grid_size=0.5)\n",
     "\n",
     "grid_cells = [MeasurementArea(cell) for cell in cells[0]]\n",
     "plot_measurement_setup(\n",
@@ -1256,8 +1267,201 @@
     "    ma_line_width=0.5,\n",
     "    ma_alpha=0,\n",
     ").set_aspect(\"equal\")\n",
-    "plt.savefig(output_path / \"profile_grid.svg\", bbox_inches=\"tight\")\n",
+    "# plt.savefig(output_path / \"profile_grid.svg\", bbox_inches=\"tight\")\n",
     "plt.axis(\"off\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Axis aligned measurement area"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"-11.826374841006373 -6.14825781358943 28.652749682012747 17.296515627178863\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,5.000000000000002)\"><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.5730549936402549\" opacity=\"0.6\" d=\"M -8.855031935484483,-5.087044862403772 L -10.765161889820716,5.745840420730515 L 13.855031935484485,10.087044862403774 L 15.765161889820718,-0.7458404207305147 L -8.855031935484483,-5.087044862403772 z\" /></g></svg>"
+      ],
+      "text/plain": [
+       "<POLYGON ((-8.855 -5.087, -10.765 5.746, 13.855 10.087, 15.765 -0.746, -8.85...>"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import shapely\n",
+    "\n",
+    "from pedpy import AxisAlignedMeasurementArea, MeasurementArea\n",
+    "\n",
+    "poly = shapely.Polygon([(-10, -3), (-10, 8), (15, 8), (15, -3)])\n",
+    "poly_rotated = shapely.affinity.rotate(poly, 10)\n",
+    "measurement_area = MeasurementArea(poly_rotated)\n",
+    "measurement_area.polygon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"-11.826374841006373 -6.14825781358943 28.652749682012747 17.296515627178863\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,5.000000000000002)\"><path fill-rule=\"evenodd\" fill=\"#66cc99\" stroke=\"#555555\" stroke-width=\"0.5730549936402549\" opacity=\"0.6\" d=\"M 15.765161889820718,-5.087044862403772 L 15.765161889820718,10.087044862403774 L -10.765161889820716,10.087044862403774 L -10.765161889820716,-5.087044862403772 L 15.765161889820718,-5.087044862403772 z\" /></g></svg>"
+      ],
+      "text/plain": [
+       "<POLYGON ((15.765 -5.087, 15.765 10.087, -10.765 10.087, -10.765 -5.087, 15....>"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "aa_ma = AxisAlignedMeasurementArea.from_measurement_area(measurement_area)\n",
+    "aa_ma.polygon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pedpy import get_grid_cells\n",
+    "\n",
+    "cells = get_grid_cells(axis_aligned_measurement_area=aa_ma, grid_size=1)\n",
+    "grid_cells = [MeasurementArea(cell) for cell in cells[0]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgMAAAE+CAYAAAAQ1xO5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAD6pJREFUeJzt3cFuK1d2BdBTUamlJ4FkU0Q6zv9/WoBMArOhJlU0FbIrg440oiHZdeu+izprTTwguLWPJ9wo02A3juMYAEBa//azCwAAP5cxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkJwxAADJGQMAkFxf6w/97//8Gqe30+SccRwjIqLrup+a0VIX9+hSM0OX+TJa6rK0e1rq8ocy+rvoX/76uy//+PE4+d9L1BwDp7dT/OO//jueHv8yKWd/HKLrIrbPTz81o6Uu7tGlZoYu82W01GVp97TU5bsZ4/Wfcf/L33739eG3c0REPD39+NNdPlQbAxERT49/idV//sekjPfXQ0RErDarn5rRUhf36FIzQ5f5MlrqsrR7Wury3Yzrr3+P/vEh+gIf9l/xnQEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkqv2E8TiOsT8Onz/d+GftD9PeXyqjpS7u0aVmhi7zZbTUZWn3tNTluxnX41v0jw9xd3/7o/p0PsfLZj25T9R+MtB1hXJielCJjJa6uEeXmhm6zJfRUpel3dNSlyIZ4+SIT9WeDHRdF9vnp1htVkXydgVySmS01MU9utTM0GW+jJa6LO2elrp8lXG9XKLfrKPfbW++PgynyR0++M4AACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACTX1/pD4zjG/jjE++thUs7+MO39pTJa6uIeXWpm6DJfRktdlnZPS12+m3E9vkX/+BB397c/qk/nc7xs1pP7RO0nA11XKCemB5XIaKmLe3SpmaHLfBktdVnaPS11KZIxTo74VO3JQNd1sX1+itVmVSRvVyCnREZLXdyjS80MXebLaKnL0u5pqctXGdfLJfrNOvrd9ubrw3Ca3OGD7wwAQHLGAAAkZwwAQHLGAAAkZwwAQHLGAAAkZwwAQHLGAAAkZwwAQHLGAAAkZwwAQHLGAAAkZwwAQHLGAAAkV+0njMdxjP1xiPfXw6Sc/WHa+0tltNTFPbrUzNBlvoyWuiztnpa6fDfjenyL/vEh7u5vf1Sfzud42awn94naTwa6rlBOTA8qkdFSF/foUjNDl/kyWuqytHta6lIkY5wc8anak4Gu62L7/BSrzapI3q5ATomMlrq4R5eaGbrMl9FSl6Xd01KXrzKul0v0m3X0u+3N14fhNLnDB98ZAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASK7aTxiP4xj74xDvr4dJOfvDtPeXymipi3t0qZmhy3wZLXVZ2j0tdfluxvX4Fv3jQ9zd3/6oPp3P8bJZT+4TtZ8MdF2hnJgeVCKjpS7u0aVmhi7zZbTUZWn3tNSlSMY4OeJTtScDXdfF9vkpVptVkbxdgZwSGS11cY8uNTN0mS+jpS5Lu6elLl9lXC+X6Dfr6Hfbm68Pw2lyhw++MwAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyfW1/tA4jrE/DvH+epiUsz9Me3+pjJa6uEeXmhm6zJfRUpel3dNSl+9mXI9v0T8+xN397Y/q0/kcL5v15D5R+8lA1xXKielBJTJa6uIeXWpm6DJfRktdlnZPS12KZIyTIz5VezLQdV1sn59itVkVydsVyCmR0VIX9+hSM0OX+TJa6rK0e1rq8lXG9XKJfrOOfre9+fownCZ3+OA7AwCQnDEAAMkZAwCQnDEAAMkZAwCQnDEAAMkZAwCQnDEAAMkZAwCQnDEAAMkZAwCQnDEAAMkZAwCQnDEAAMlV+wnjcRxjfxzi/fUwKWd/mPb+UhktdXGPLjUzdJkvo6UuS7unpS7fzbge36J/fIi7+9sf1afzOV4268l9ovaTga4rlBPTg0pktNTFPbrUzNBlvoyWuiztnpa6FMkYJ0d8qvZkoOu62D4/xWqzKpK3K5BTIqOlLu7RpWaGLvNltNRlafe01OWrjOvlEv1mHf1ue/P1YThN7vDBdwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAILm+1h8axzH2xyHeXw+TcvaHae8vldFSF/foUjNDl/kyWuqytHta6vLdjOvxLfrHh7i7v/1RfTqf42Wzntwnaj8Z6LpCOTE9qERGS13co0vNDF3my2ipy9LuaalLkYxxcsSnak8Guq6L7fNTrDarInm7AjklMlrq4h5damboMl9GS12Wdk9LXb7KuF4u0W/W0e+2N18fhtPkDh98ZwAAkjMGACA5YwAAkjMGACA5YwAAkjMGACA5YwAAkjMGACA5YwAAkjMGACA5YwAAkjMGACA5YwAAkjMGACC5aj9hPI5j7I9DvL8eJuXsD9PeXyqjpS7u0aVmhi7zZbTUZWn3tNTluxnX41v0jw9xd3/7o/p0PsfLZj25T9R+MtB1hXJielCJjJa6uEeXmhm6zJfRUpel3dNSlyIZ4+SIT9WeDHRdF9vnp1htVkXydgVySmS01MU9utTM0GW+jJa6LO2elrp8lXG9XKLfrKPfbW++PgynyR0++M4AACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACRnDABAcsYAACRnDABActV+wngcx9gfh3h/PUzK2R+mvb9URktd3KNLzQxd5stoqcvS7mmpy3czrse36B8f4u7+9kf16XyOl816cp+o/WSg6wrlxPSgEhktdXGPLjUzdJkvo6UuS7unpS5FMsbJEZ+qPRnoui62z0+x2qyK5O0K5JTIaKmLe3SpmaHLfBktdVnaPS11+SrjerlEv1lHv9vefH0YTpM7fPCdAQBIzhgAgOSMAQBIzhgAgOSMAQBIzhgAgOSMAQBIzhgAgOSMAQBIzhgAgOSMAQBIzhgAgOSMAQBIzhgAgOSMAQBIrq/1h8ZxjP1xiPfXw6Sc/WHa+0tltNTFPbrUzNBlvoyWuiztnpa6fDfjenyL/vEh7u5vf1Sfzud42awn94naTwa6rlBOTA8qkdFSF/foUjNDl/kyWuqytHta6lIkY5wc8anak4Gu62L7/BSrzapI3q5ATomMlrq4R5eaGbrMl9FSl6Xd01KXrzKul0v0m3X0u+3N14fhNLnDB98ZAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASM4YAIDkjAEASK7aTxiP4xj74xDvr4dJOfvDtPeXymipi3t0qZmhy3wZLXVZ2j0tdfluxvX4Fv3jQ9zd3/6oPp3P8bJZT+4TtZ8MdF2hnJgeVCKjpS7u0aVmhi7zZbTUZWn3tNSlSMY4OeJTtScDXdfF9vkpVptVkbxdgZwSGS11cY8uNTN0mS+jpS5Lu6elLl9lXC+X6Dfr6Hfbm68Pw2lyhw++MwAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJCcMQAAyRkDAJBctZ8wHscx9sch3l8Pk3L2h2nvL5XRUhf36FIzQ5f5MlrqsrR7Wury3Yzr8S36x4e4u7/9UX06n+Nls57cJ2o/Gei6QjkxPahERktd3KNLzQxd5stoqcvS7mmpS5GMcXLEp2pPBrqui+3zU6w2qyJ5uwI5JTJa6uIeXWpm6DJfRktdlnZPS12+yrheLtFv1tHvtjdfH4bT5A4ffGcAAJIzBgAgOWMAAJIzBgAgOWMAAJIzBgAgOWMAAJIzBgAgOWMAAJIzBgAgOWMAAJIzBgAgOWMAAJIzBgAgOWMAAJLra/2hcRxjfxzi/fUwKWd/mPb+UhktdXGPLjUzdJkvo6UuS7unpS7fzbge36J/fIi7+9sf1afzOV4268l9ovaTga4rlBPTg0pktNTFPbrUzNBlvoyWuiztnpa6FMkYJ0d8qvZkoOu62D4/xWqzKpK3K5BTIqOlLu7RpWaGLvNltNRlafe01OWrjOvlEv1mHf1ue/P1YThN7vDBdwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAIDljAACSMwYAIDljAACSq/YTxuM4xv44xPvrYVLO/jDt/aUyWuriHl1qZugyX0ZLXZZ2T0tdvptxPb5F//gQd/e3P6pP53O8bNaT+0TtJwNdVygnpgeVyGipi3t0qZmhy3wZLXVZ2j0tdSmSMU6O+FTtyUDXdbF9forVZlUkb1cgp0RGS13co0vNDF3my2ipy9LuaanLVxnXyyX6zTr63fbm68Nwmtzhg+8MAEByxgAAJGcMAEByxgAAJGcMAEByxgAAJGcMAEByxgAAJGcMAEByxgAAJGcMAEByxgAAJGcMAEByxgAAJGcMAEByfa0/NI5j7I9DvL8eJuXsD9PeXyqjpS7u0aVmhi7zZbTUZWn3tNTluxnX41v0jw9xd3/7o/p0PsfLZj25T9R+MtB1hXJielCJjJa6uEeXmhm6zJfRUpel3dNSlyIZ4+SIT9WeDHRdF9vnp1htVkXydgVySmS01MU9utTM0GW+jJa6LO2elrp8lXG9XKLfrKPfbW++PgynyR0+VBsDERHj9Z9x/fXvkzKux7d//fNy+akZLXVxjy41M3SZL6OlLku7p6Uu380Yr9c//Tf+qHpjoL+L+1/+Fv3jw7SY/39/P+G/k5TIaKmLe3SpmaHLfBktdVnaPS11+SMZ/S///qf/zh9RbQz0L3/91z+ffkzK+fgixe89NqmV0VIX9+hSM0OX+TJa6rK0e1rqUuqekvyvhQCQnDEAAMkZAwCQnDEAAMkZAwCQnDEAAMkZAwCQnDEAAMkZAwCQnDEAAMkZAwCQXNVfLRx+O0/OOJ3P0Y3TfrqxREZLXdyjS80MXebLaKnL0u5pqUupe4bfzvE08cf/PnTjOI5Fkr4wjmOcTr8VyYmI6Lrup2a01MU9utTM0GW+jJa6LO2elrqUuici4sePxyI51cYAANAm3xkAgOSMAQBIzhgAgOSMAQBIzhgAgOSMAQBIzhgAgOSMAQBIzhgAgOSMAQBIzhgAgOT+D+AWrcIkJyYcAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import shapely.plotting\n",
+    "\n",
+    "xmin, ymin, xmax, ymax = aa_ma.polygon.bounds\n",
+    "\n",
+    "ax = plot_measurement_setup(\n",
+    "    # walkable_area=walkable_area,\n",
+    "    # hole_color=\"lightgrey\",\n",
+    "    measurement_areas=grid_cells,\n",
+    "    ma_line_color=pedpy_grey,\n",
+    "    ma_line_width=0.1,\n",
+    "    ma_alpha=0,\n",
+    ").set_aspect(\"equal\")\n",
+    "\n",
+    "\n",
+    "# shapely.plotting.plot_polygon(\n",
+    "#     measurement_area.polygon, ax=ax, color=pedpy_blue, alpha=0.7, edgecolor=pedpy_blue, add_points=False, linewidth=1.2\n",
+    "# )\n",
+    "\n",
+    "shapely.plotting.plot_polygon(\n",
+    "    aa_ma.polygon,\n",
+    "    ax=ax,\n",
+    "    color=pedpy_red,\n",
+    "    alpha=0.2,\n",
+    "    edgecolor=pedpy_red,\n",
+    "    add_points=False,\n",
+    "    linewidth=1.2,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "plt.xlim([xmin - 1, xmax + 1])\n",
+    "plt.ylim([ymin - 1, ymax + 1])\n",
+    "plt.axis(\"off\")\n",
+    "plt.savefig(\n",
+    "    output_path / \"profile_axis_aligned_measurement_area_with_grid.svg\",\n",
+    "    bbox_inches=\"tight\",\n",
+    ")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAgMAAAE+CAYAAAAQ1xO5AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjMsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvZiW1igAAAAlwSFlzAAAPYQAAD2EBqD+naQAAHsVJREFUeJzt3VtT5Ep6heGVpypVQ3dT0BOzwxF2+Mb/x3/el+MbO2zPRHPcNHWQlOkLqYqCpqGgoSSl3ifCsa9sxHg2ubSU+aVJKSUBAIDRsl0/AAAA6BZhAACAkSMMAAAwcoQBAABGjjAAAMDIEQYAABg5wgAAACNHGAAAYOQIAwAAjBxhAACAkSMMAAAwcoQBAABGjjAAAMDIEQYAABg5wgAAACNHGAAAYOQIAwAAjBxhAACAkSMMAAAwcoQBAABGjjAAAMDIEQYAABg5wgAAACNHGAAAYOQIAwAAPLKsomJKXT/GwfhD/aDq+4VU1Yf6cQAAvKhOSderWlfLShfLSlerUt8XlX6so/793051NgvdPqB38t9OP/7HfPhP2Khqlf/zdxlHGQEAOKyUpEUV9ee61k37P3+uKl2tKpV1UhWlKkaVKUlJKrzTzazS1y+T7p65jgr/9NeD/KzDhQFJxlm5s/khfyQAYGTWddLVqtLlstLVstLVstb5stSPslZZJ5UxqYxGSV7OBYWJ0cRaBStNrVEVk76van2fHelfz447+z3q88uD/ayDhgEAAN5LjNL1ulnwL9u3/ItFpetVpbKWyhhVxqQ6JVkZBWcUrNHRxCpYI2PMk/93vZWqlHS5rA7+O3WFMAAA6LWUpLuybhb85eaflc4Xpdbtm/66jqpSkpHkrdXEGk291bE1ckbSLxb+JxkjI+lyQRgAAODgHlf8l+3GvocVf1JSkjebt32rmXfy1rxu0X9GcFY3ZaVlFVX4/Pe6EQYAAAf3U8W/rHS+qHSzbir+dYyq6qRaSU5Gfs+K/70EY1TW0tWq0h++u02Eh0IYAAB8mN2K/3JZt2/8pS6WldZ10jomlTsVf7DNYl94qzB5Q8X/TrwzWlZRl8tafxwd/McfHGEAAPAunqr4z5eV7l6o+D+9c8X/HibW6LYezyZCwgAA4FU2Ff/lstnB37eK/z1Ya1SrCTdjQBgAADwpJelHWbdv+w8r/tXmTb+HFf97ccbofFEqpUH/GnshDAAAHlT8m5p/qBX/e/HWaFFF3Za1Pk9c14/zoQgDADAidZRudir+y2U7qGd9P6hn6BX/ewnWqmr3DRAGAACDs6n47xf9WlfLUuftLv7cK/73EJz0Y510taz0L1+mXT/OhyIMAMDArdu3192d/D9X/FFJaiv+ZuHPueJ/D8EalTGOYhMhYQAABuKpin93F//zFb8bVcX/HowxSpIuRjCWmDAAAD3zc8V/P5aXiv+wvDW6WFaqo+QynkpMGACADq3q9GAk7+Zt/66qVVHxdy5YqzImXa8qnc7yXTLz/c0AoEfqKF2vdr7rr6j4h6DZN9DsySAMAAD28suKf1E1c/ip+AclWOmuzH8TIWEAAN5ot+Lf7OL/vii1qOKDil/tNDsq/uHx1qhK+d9RQBgAgBe8quI3Rt5S8WfDGBlJF4QBABiHlKTbst5u5Nud0EfFP17BWt2sKy2rqMLneaSAMABglFbtoJ7dm/eo+PGUYI3KWrpaVfrDT7p+nA9BGACQtbdV/FZHE0PFD0mSd0bLKupyWeuPo66f5mMQBgBk4TUVv5Xkqfixp2CNbttbHXNFGAAwOK+q+Ns3fSp+vJWzRrWakyO5IgwA6K1Nxf/gTX9JxY/Dc8bo+6JUSnlmScIAgM5tKv7NWf3dS3jKfXbx2wz/OqNXvDVaVFG3Za3PE9f147w7wgCAg1pWsV3s651F/+eKP7V/gKn40QfBWlXt5ynCAADsabfi30zou1xUuimp+DE8wUk/1s2+gX/5Mu36cd4dYQDAb/mp4m+/618sf1HxO6tgqPgxLM2FRfneUUAYALC33Yr//sw+FT/yZ4xRkrK9o4AwAOAnddT2yB4VP9Dw1uh8UamOkstsKjFhABix36n4JxMjS8WPEQnWqoxJ16tKp7O8ls+8fhsAv/RUxf/9rtSybt7y1zGpYlAP8EvNvoFmEiFhAECvVTHpqj22t6n5LxaV/nyh4j+m4geeFax0V8Ys9w0QBoCBelzxb8bzUvEDH8NboyolwgCAbjQ3pjVv+Zu3/scVfxmjzE7FP6HiB96XMbKSLggDAD7SUxX/+aLS7U7FX9ZJsa34gzMKxurzxMhT8QMfzlurm3WlVZ00dfn8+0YYADqwW/Ff7uziv9yp+Nd1VP2o4p95qy9U/EBngjUq62bewB9HoevHeTeEAeCDLauoi+1Vuw8r/nJnUM+m4p9Q8QO95Z3ZfrYjDAD4yVsr/oKKHxiMYI1u65TdWGLCAPBKKUl/ritdrer9K35LxQ/kwBmpVnNhUU4IA8AzFm0duHnbv1rW+r54uuL37OIH8meMnDH6viiVUj7/ihMGgEcV/+55/dt1pTJS8QO4563Rooq6LWt9nriuH+ddEAYwKpuK/7Idy7up+K+WVXtWvxnUU6ck21b8noofwI5graq6+VRAGAB6LKV2UM+m3m/f+M8XlZZVvJ/Q187iD23FP3VGR1T8AJ4RnPRj3Uwi/Ocv064f510QBjB4ZUy6flzxb3bx/6rit1aFp+IH8HrNhUUxqxMFhAEMBhU/gD4wxihJWd1RQBhA7+xX8Tf/3N3FT8UP4FC8MbpYVKqj5GzXT/P7CAPoVLnZxb+9hKdZ9H+UldZRqn5Z8TeLPhU/gC4EZ7WOSderSqez4S+lw/8NMAgpSTfrdg7/6hUVf6DiB9A/zb6BZhIhYQB45Pcqfi9vRcUPoPeCle7KmM2+AcIA3uzpir/Uj7Km4geQNW+NqpTPHQWEAbzoYcXf7OS/XJbtLH49qvibRZ+KH0DWjJGRdL4gDCAz24p/p96/XFY6X1ZaUfEDwAPBWt2sK63qpKkb9t8+wsBIbSr+3Ut4zhelbstaZS1V6dcVf+DoHgA0mwjrZt7AH0eh68f5LYSBzL254mdQDwA8yzuzbVMJA+iFxxX/5tjeXhV/8PKGih8AXiNYo9s6j02EhIEBelDxt4s/FT8AHJYzUq3m9sKhIwz02G7FvxnWs634a6lMVPwA0Blj5IzR90WplIb9nkUY6IGUpMWjXfybsbyr+nHFb+StqPgBoAe8NVpUUT/KWscT1/XjvBlh4MDKmNrFvt5W/N/bQT1l3Q7qiVT8ADAEwRpVdfN3nTCAnzyu+C9XlS4XzeLfVPzNd/2fKv6J1RdDxQ8AQxCc0Y910+z+85dp14/zZoSB3/Sg4t8s+stKF7sVfx1VpscVv9VRMFT8ADBgzYVFcfAnCggDr1DWqZ3BT8UPAND2jpWhX1hEGHhCjG3Fv9p529+34rdGlkUfAEbDGaOLRaU6Ss52/TRvM+owkJJ0V9a6WtV7VPySt1bBGip+AMBWcFbrmHS9qnQ6G+ayOsynfoP7iv/+zP75tuJPqmLSOiYlKn4AwCs0+waaSYSEgZ7Yrfi35/Z3K/72uz4VPwDgPQQr3ZVx0PsGBhsGdiv+3WE9jyv+KiVpt+L3VkeWih8A8D68NarSsO8oGEQYWLcXQbym4p9Yq5l38lT8AICPZIyMpPMFYeBdxChdr3dG8q6aN/3rFyr+T1T8AIAOBWt1s660qpOmbnhrUSdh4HHFv9nY9+Iufm91bI0cFT8AoEeCNSpr6WpZ6a9HoevHebWDhYH/+7HW//zjTv+4Njpf3lf8zSU8VPwAgOHyzmhZRV2uCAPPOl9U+o/vd/rf6cOK/2hi5an4AQADFqzRbZ10NdATBQcLA6czJ2OkI+90PB3uzU4AADzmjFQrDfZ44cEGJ55Mg7xrrvAFACArxsjJ6PuiVBrgMnewMDDzVsfBq4zxUD8SAICD8c5oUUX9KOuuH+XVDnqlwteJU1J7nAAAgIwEa1TVw/xUcNAw8GXq5I1RxacCAEBmgru/o2BoDhsGJl7BWZV8KQAAZKa5sGiYdxQcOAy47e1OAADkxBijJBEGXnK8DQNUAwCA/HhjdLGoVA9smTtoGHBWOpt59gwAALIUnNU6Jl0PbN/AQcOAJM0LLyMpcaIAAJCZzafwoW0iPHgYOJl6BWvZNwAAyE6wUlkPbxPh4cNA4be3OwEAkBNvjapEM/CieeHlHZsIAQAZMkamvZxvSA4eBo6D08xbNhECALIUrNXNutK6Hs46d/AwYIx0Nguq2UAIAMjQ5lP4kPYNHDwMqP1U4GRU0w4AADKz+RR+OaB9A52EgZPpZt8AYQAAkJfNhUVXNAPPmxdOwVpVA/qeAgDAPpyRag3r9sLOmoHgRDMAAMiPMXIyOl9UGsr2uE7CQOGtvgSviuOFAIAMeWe0qGr9GMhQnU7CgCTNZ15R0mBiEwAAe2pOFAznU0F3YaDw8sYwbwAAkJ3ghnVHQXdhYOoVnFXJlwIAQGaaC4uGc0dBp83A5nYnAAByYoxR0nAGD3UWBr5O/TY5AQCQG2+MLhaV6gEsc52FAWel08KzZwAAkKXgrNYx6Wbd/3agszAgNWHASEqcKAAAZGbzKXwInwo6DQMnhVewln0DAIDsBCuVdRzEiYIehIHmdicAAHLirVGVaAZeNC/89nYnAACyYoyMpPMFYeBZx8Fp5i2bCAEAWQrW6mZdad3zi/k6DQPGSGezoJoNhACADG0+hff9U0GnYUDtDYZORjXtAAAgM5tP4X3fRNh5GLjfN0AYAADkJVijagAXFvUgDDgFa1X1/HsKAACv5YxUK+mKMPC8k6lXcFLJvgEAQG6MkZPR90WlPi9znYeBwlt9CV7lEIY3AwDwSt4ZLapaP3o8VKfzMCBJ85lXktTr2AQAwBs0Jwr6vW+gH2Gg8PLGMG8AAJCd0G6S7/OJgn6EgalXcFYlXwoAAJm5v7CIzwTP2t5RQDMAAMiMMUZJSVfLsutH+aV+hIHpJgxQDQAA8uON0cWyUl+XuV6EAWel08KzZwAAkKXgjNZ10vW6n/sGehEGpCYMGEmJEwUAgMwEa7WO/T1R0Jsw0OwbsOwbAABkJ1iprPt7R0HPwkBzuxMAADnx1qhKNAMvur+wqKe7KwAAeCtjZCRdLAgDzzoOToWzbCIEAGQpWKubdaV1Dy/m600YMEb69imoZgMhACBDm0/hfdw30JswoHbegJNRpB0AAGTGO6N1jL3cN9CrMLDZN7AmDAAAMhOsUdXTC4t6FgacgrWqevg9BQCA3+GMVCvpijDwvJOpV3BSyb4BAEBujJGT0fmyUt+WuV6FgcJbfQ5eZc3xQgBAfrwzuitr/ejZUJ1ehQFJOp15JUm9i00AAPym5kRB6t2Jgt6FgfnUyxvDvAEAQHaCMypj0uWSZuBZ88IrOKuSLwUAgMwEuwkDNAPP2t5RQDMAAMiMMUZJSVfLsutHeaB/YWC6CQNUAwCA/HhjdLGs1KdlrndhwFnptPCqaQYAABkKzmhdJ12v+/OpoHdhQO2+AUlKnCgAAGQmWKt1z/YN9DYMeGvZNwAAyE6wUlnHXh0v7GUYOCm8Ju3tTgAA5MRboyr1ayxxL8PA5sIiNhECALJjjIyk8wVh4FnHwalwlsFDAIAsBWt1s6607snFfL0MA8ZI3z4F1WwgBABkKLSfwvuyb6CXYUDtvAEno0g7AADIjHdG6xh7c6Kgv2GgcO1/WIQBAEBegjWq6v5sIuxtGJhPvYK1qnryPQUAgPfijFSrP7MG+hsGCq/gpJJ9AwCA3Bgjp2YscR+Wud6GgcJbfQ5eZc3xQgBAfrwz+lHWuuvBUJ3ehgFJOp15JUm9iE0AALyj5kRB0mUPThT0OgzMp17eGOYNAACyE5xRGZMulzQDzzopvIKzqvhSAADITLCbMEAz8KyTqVewHC8EAOTHGKOkpKtl2fWj9DwMFK5NTlQDAID8ONOcKOh6met1GPDWaF541TQDAIAMTZzRuk66Xnf7qaDXYUCSTovmREHiRAEAIDPBWpWx+0mEvQ8D86KdREg7AADITLBSWcfOjxf2PgycFF6T9nYnAABy4q1RmWgGXjQvvLwzKhObCAEAmTFGRtL5gjDwrOPgVDirkguLAAAZ8tbqZl1p3eE61/swYIz07VNQzQZCAECGQvsp/KrDfQO9DwNqhw9ZGUU2EQIAMtOMJY6dTiIcRhgo3HaGMwAAOdmMJe5yE+EgwsB82hwvZN8AACA3zkh16vaOgmGEgcIrOKlk3wAAIDfGyKoZS9zVMjeIMFB4q+PgVdYcLwQA5Cc4ox9lrbuOhuoMIgxI0tmsGUvcWWwCAOCDeGtU1qmzSYSDCQPzqZczhrHEAIDsTNxmEyHNwLNOCq+Js6r4UgAAyIxvTxTQDLzgZOq3xy8AAMiJNUZJ3R0vHE4YKJyCNVpHqgEAQH6cMTpflOpimRtMGPDWaF541TQDAIAMBWe0rpOu14dvBwYTBiTptGhOFCROFAAAMjOxtrNJhIMKAydFM4mQEwUAgNwEK5V17GQT4aDCwLzw29udAADIibdGZUqd3F44qDBwMm0vLEpsIgQAZMYYGUkXC8LAsz5PvArHhUUAgDx5a3W9qrQ+8Do3qDBgjPTtU1DNBkIAQIY2n8IP/algUGFA7fAhK6PIJkIAQGaCMypjPPh1xsMLA0W7b4AwAADIzGbS7qGPFw4vDEyb44WEAQBAbpyR6nT4C4sGFwbmhVdwIgwAAPJjjKyMzpelDrk9bnBhYOatjoNXWXO8EACQn+CMfpS1Fge8pndwYUCSzmbNWOKDxiYAAA7AW6OyTvpzfbhPBYMMA/OplzOGscQAgOxMXLO+3RAGnndSeE2c1QEbFAAADsJbozVh4GXNiQKOFwIA8mONUVLSnwccPDTMMFC4NgxQDQAA8uOM0fWqPtjE3UGGAW+NTgpPMwAAyFJwRus66np1mE8FgwwDknRaeElS4kQBACAHKamqoxZlVBWTqqiDTSL0B/kpH2BeNJMIq5gUnOn6cQAA2E9KqlMzPK+qk8qYVMaoJMkbo+CsPnmnWTC6Kw/TDAw8DDS3OwXX9dMAAPCzlNrFvl30qzqpVpKTkXdGwVodTYy+TCY6m3mdTL3mRfPP49uppn85OshzDjYMnEybC4tWdRzy1w4AQA5SUhWTyqh28Y+qUpKRFKxVsEaFt/pUOJ3N2gW/8JpPm39On2i467vDPf5gw8DniVfhrG4PeA4TADBye1T8wRodea/TdtHfvOnPC6+j4GR6+GV7sGHAGOnbLOjvd+uuHwUAkKHXVvy7i/6XiZcbUGk92DCgdt6AlVGMSdb2MGoBAPrvQcUfVdbpp4p/5q1mhdO3WVvvtwv/ryr+oRl2GJh6BddMIpwSBgAAz9mr4rc68qbZzFcEzQvX+4r/PQw7DLTHC8uYNO36YQAAvbFvxf91Mtl+2x9qxf8eBh0GmuOF0l3F4CEAGKVfVvxGwZpfVvybxX+SQcX/HgYdBmbe6njidb1adv0oAICPtEfFP7FWx8HotNhU/H5b8+dc8b+HQYcBtWOJ/+vP5r8o/H8aAIbvpYp/Yq2Odwf17FT8XydedmQV/3sYfBiYF17OGFUxyVP3AMBw7Fnxf5o5nRU7g3qo+N9dFmEgOKsqSp6xxADQP79R8c+nXp+o+D/c4MPAybS9oyAmFV0/DACMHBX/MA0+DHwtnCbW6KaqJVENAMBB7FT867bir6n4B2vwYSBYo5PC63xZdv0oAJCfnYp/+7bfVvyhrfin1upzMDqbhZ3Ld6j4h2TwYUDtiYL/bOspw3/rAOBNYvu2v67bt/46KSrJmc3bvlUxMfo6bQb1nEzvb92j4h+2LMLASeHlrVUVkwLVEwA8b8+K/9vM6awIOikcFX/msggD88K1mwilwLYBAGjsWfF/CbZ5028r/mbRd1T8I5JHGGhPFKxilERPBWB83lTxt2/6VPzIIgx8nngV3up2UXf9KADwsTZH93YG9Wwq/ok18rsV/yzoZOq2O/mp+PErWYQBY6Szmdff79ZdPwoAvI+UVCVt3/I3Fb92BvXsVvy7t+5R8eO1sggDaicRWhnFmGQt/wYAGI64M6jnuYr/ZDrRfKfin0+b63ap+PG7sgkDJ1Ov4JpJhFPCAIA+erHit5p586jiD9sz+5yWwkfJJwwUXsHaJgx0/TAAxu2nij+qilJSenIX/7y4P69PxY8uZBMGmhMF0l2Vun4UACPybMXvjIKxKiauqfZn94s+FT/6JJswUHir4+B1vVp2/SgAcvSLit+2g3p2K/5vs6CTzZs+FT8GIJswYIx0OvP6r9vmX1o6NgBv8hsV/7zwmnnLnx8MTjZhQO2JAmeMqpjkSeEAXvB8xW8VjPmp4p+3i/7nQMWPfGQXBoKzqlJmvxiA3/Ncxe+MvKHix7hltWaetGOJyzqpyOo3A7CX5yr+9rz+puI/m/kHl+9Q8WPMsloyvxZOE2t0U9WSuLEIyFmMSWV6ueJvav37sbxU/MDPsgoDwRqdFF4Xy7LrRwHwXvas+P+yHdSzU/EXTVsI4HlZhQFJOi28/iYppSRD3wcMx5MVf2qu2/1FxX+6U/EXVPzAm2UXBk7aN4EqJjb9AD31YsVvjQp/X/HPC7dd9L9MPIs+8M6yCwPzwrVjiaXAtgGgW6+t+Hdv3iscFT9wIPmFgfZEwSpGSewQAg4iJVVRqtLzFf/XidVpcX9Wn4of6IfswsDnSfOH5XZRd/0oQJZ+rvijokTFDwxYdmHAGOls5vX3u3XXjwIMWkrtYv+rit9affJGR7OwrfjnOzv5qfiB4cguDKidRGhlFGOS5Q8S8Lx20a+S9qr4T2d+e3xvPqXiB3KQZRg4aceHlilpKv5KARsxbjb0/brin/mdY3uF3w7roeIH8pVnGCi8vLUq66QpJwowQi9V/KGt+I9nk+ZNn4ofGLUsw8B86jWx0l2Vun4U4GM9UfGXsfnvfbDNm/6m4j+b3e/gp+IHsCvLMFB4q6Pgdb1adv0owLt5S8U/b2/d+0zFD+AZWYaBzYmC/75t3pz4K4gh2Vb8tVSmlyv+3TP7X6n4AbxBlmFA7b4BZ4yqKHn2DaCPNhV/VPvG/0TF75qK/9ss6KQ9r0/FD+C9ZRsG5lOv4KyqlOQ5UYCO7Vb8ZVvxp7bin1DxA+hYtmFgc2FRWScV2f6W6Jt9Kv6jYHT8afLTWF4qfgBdyXaZPCmcJtbopqol8Z0A7+xRxb+OUfV2UM9TFb/f1vzzwmvmuTcDQH9kGwaCNTopvC6WZdePgoHbVvz1Zib/0xX//EHF3wzroeIHMATZhgFJOi28/iZOFGA/e1X8vqn4z2Y7Q3qo+AEMXNZhYLtvICYFxx9qtHYq/nW7i3+34p/sVvyfQruDn4ofQL7yDgNTp2CtyigFtg2MUoxJ65hUPar4/c6gnk9PVPzzwus4OAolAKOQdRiYt83AKkZJvM3lLKXNd31tb92rU5KTkX+h4j8pnDwVP4ARyzoMfJk0g1luF3XXj4L38uACnvuKX5J8W/EX3qpwDyv+eVvxF1T8APCTrMPAZizx/92tu34UvMG+Ff+D8/pU/ADwalmHAbWfCpyMYkyyVMG9tG/F//lTO4t/unt8z8vxsg8AvyX7MHAy9QrOqExJU8YSd+uJir+KSWZnUM9TFf9pu+hT8QPAx8g/DBRe3liVddKUEwUHU2+u2t2j4t/s4qfiB4BuZB8G5lOviZPuqtT1o2Rp34r/y6eJ5pvrdnd28lPxA0D3sg8Dhbc6Ck7XK04U/JY3VPzz9uY9Kn4A6Lfsw0BzoiDov29XjCXe04OKv134qfgBIF/ZhwG1+wacMaqi5Nk3sLVXxT8x+hIeVvzzwusrFT8AZGMUYWA+9QrOqkpJfownCvas+Gfe6mwWtkf2qPgBYBxGEQa2FxbVSUXOv3FKqpP2qvjPZvfn9Kn4AWDccl4at04Kp2ClZRUl5fGdYO+KfzLZTug7oeIHADxhFGEgWKN54XW5rLp+lNd7XPHXUXVqjkk+rvi/zcL2yF6z+DsqfgDAi0YRBiRpXgQlLft7ouCNFf9mHj8VPwDgrUYUBlyzbyAmBdftqnlf8bdH+J6p+M9mu2/6VPwAgPc3mjBwMvUK1qqMUjjUtoEnKv4qPb2L/3HFPy+8ph2HFgDAOIwmDMzbEwWrGCW986v1nhX/kffNrXtU/ACAHhlNGPgy8Zp6q9vF740l/qnir5NqUfEDAIZrNGHAGOms8PrH3Xq//4V9K/6iqfg3b/mbS3io+AEAQzGaMKD2U4GVUYxJ1raL9Rsq/t2a/4iKHwAwcKMLA8EZXa9qGSMqfgAADh0GUh1Vn18e8kc+8JdVrb+ufqismxMFU+d0Ujh9mXh9nlp9nTh9njhNnJGUJJVSXUp3ku4kLkEGABxKqg+36piU2nF2H6z6fiFV3S+nf65rXS6rdha/laHjBwD0lP/jLwf5OQcLAwAAoJ/4Cg4AwMgRBgAAGDnCAAAAI0cYAABg5AgDAACMHGEAAICRIwwAADByhAEAAEaOMAAAwMgRBgAAGDnCAAAAI0cYAABg5AgDAACMHGEAAICRIwwAADByhAEAAEaOMAAAwMgRBgAAGDnCAAAAI0cYAABg5AgDAACMHGEAAICRIwwAADByhAEAAEaOMAAAwMj9P/d4lzbtQcxBAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import shapely.plotting\n",
+    "\n",
+    "xmin, ymin, xmax, ymax = aa_ma.polygon.bounds\n",
+    "\n",
+    "# ax = plot_measurement_setup(\n",
+    "#     # walkable_area=walkable_area,\n",
+    "#     # hole_color=\"lightgrey\",\n",
+    "#     measurement_areas=grid_cells,\n",
+    "#     ma_line_color=pedpy_grey,\n",
+    "#     ma_line_width=0.1,\n",
+    "#     ma_alpha=0,\n",
+    "# ).set_aspect(\"equal\")\n",
+    "\n",
+    "\n",
+    "shapely.plotting.plot_polygon(\n",
+    "    measurement_area.polygon,\n",
+    "    ax=ax,\n",
+    "    color=pedpy_blue,\n",
+    "    alpha=0.7,\n",
+    "    edgecolor=pedpy_blue,\n",
+    "    add_points=False,\n",
+    "    linewidth=1.2,\n",
+    ")\n",
+    "\n",
+    "shapely.plotting.plot_polygon(\n",
+    "    aa_ma.polygon,\n",
+    "    ax=ax,\n",
+    "    color=pedpy_red,\n",
+    "    alpha=0.2,\n",
+    "    edgecolor=pedpy_red,\n",
+    "    add_points=False,\n",
+    "    linewidth=1.2,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "plt.xlim([xmin - 1, xmax + 1])\n",
+    "plt.ylim([ymin - 1, ymax + 1])\n",
+    "plt.axis(\"off\")\n",
+    "plt.savefig(\n",
+    "    output_path / \"axis_aligned_measurement_area_from_measurement_area.svg\",\n",
+    "    bbox_inches=\"tight\",\n",
+    ")\n",
     "\n",
     "plt.show()"
    ]
@@ -1605,21 +1809,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pedpy-313-venv (3.13.5)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/user_guide.ipynb
+++ b/notebooks/user_guide.ipynb
@@ -3276,9 +3276,10 @@
    "source": [
     "### Profiles\n",
     "\n",
-    "For the computation of the profiles the given {class}`walkable area <geometry.WalkableArea>` is divided into square grid cells.\n",
+    "For the computation of the profiles the given {class}`walkable area <geometry.WalkableArea>` or {class}`axis-aligned measurement area <geometry.AxisAlignedMeasurementArea>` is divided into square grid cells.\n",
     "Each of these grid cells is then used as a {class}`measurement area <geometry.MeasurementArea>`  to compute the density and speed.\n",
     "\n",
+    "When using the whole walkable area for the computing the profiles, the used grid will look like this:\n",
     "```{eval-rst}\n",
     ".. image:: /images/profile_grid.svg\n",
     "    :width: 70 %\n",
@@ -3286,8 +3287,22 @@
     "```\n",
     "\n",
     ":::{note}\n",
-    "As this is a quite compute heavy operation, it is suggested to reduce the trajectories to the important areas and limit the input data to the most relevant frame interval.\n",
-    ":::"
+    "As this is a quite compute heavy operation, it is suggested to reduce the trajectories to the important areas and limit the input data to the most relevant frame interval. \n",
+    "\n",
+    "In *PedPy* it's possible to pass an axis-aligned measurement area as option to the profile computation, this will retrict the computation to this area.\n",
+    ":::\n",
+    "\n",
+    "\n",
+    "As the profiles are computed on a square axis-aligned grid, the computation can only be restriced to axis-aligned measurement areas! \n",
+    "For an arbritraty shaped measurement area, internally the grid would be created for the bounding box of that measurement area. \n",
+    "We decided to make this step explicit and visible to the users.\n",
+    "The resulting grid of such an axis-aligned measurement area, could look like this:\n",
+    "\n",
+    "```{eval-rst}\n",
+    ".. image:: /images/profile_axis_aligned_measurement_area_with_grid.svg\n",
+    "    :width: 70 %\n",
+    "    :align: center\n",
+    "```\n"
    ]
   },
   {
@@ -3353,6 +3368,101 @@
     "    resorted_profile_data,\n",
     ") = compute_grid_cell_polygon_intersection_area(\n",
     "    data=profile_data, grid_cells=grid_cells\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an axis-aligned measurement area to speed-up the profile computation. This can either be done directly from the bounding box of the desired measurement area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pedpy import AxisAlignedMeasurementArea\n",
+    "\n",
+    "profile_measurement_area = AxisAlignedMeasurementArea(-1.5, 0.5, 1.5, 2.8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternatively, an axis-aligned measurement can be created from a given measurement area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pedpy import AxisAlignedMeasurementArea, MeasurementArea\n",
+    "\n",
+    "measurement_area = MeasurementArea(\n",
+    "    [(-1.5, 0.5), (1.5, 0.5), (1.5, 2.8), (-1.5, 2.8)]\n",
+    ")\n",
+    "profile_measurement_area = AxisAlignedMeasurementArea.from_measurement_area(\n",
+    "    measurement_area=measurement_area\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from pedpy import plot_measurement_setup\n",
+    "\n",
+    "plot_measurement_setup(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_areas=[profile_measurement_area],\n",
+    "    ma_line_width=2,\n",
+    "    ma_alpha=0.2,\n",
+    ").set_aspect(\"equal\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pedpy import (\n",
+    "    compute_grid_cell_polygon_intersection_area,\n",
+    "    get_grid_cells,\n",
+    ")\n",
+    "\n",
+    "grid_cells_measurement_area, _, _ = get_grid_cells(\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    ")\n",
+    "\n",
+    "min_frame_profiles = 250  # We use here just an excerpt of the\n",
+    "max_frame_profiles = 400  # trajectory data to reduce compute time\n",
+    "\n",
+    "profile_data = profile_data[\n",
+    "    profile_data.frame.between(min_frame_profiles, max_frame_profiles)\n",
+    "]\n",
+    "\n",
+    "# Compute the grid intersection area for the resorted profile data (they have the same sorting)\n",
+    "# for usage in multiple calls to not run the compute heavy operation multiple times\n",
+    "(\n",
+    "    grid_cell_intersection_area_measurement_area,\n",
+    "    resorted_profile_data_measurement_area,\n",
+    ") = compute_grid_cell_polygon_intersection_area(\n",
+    "    data=profile_data, grid_cells=grid_cells_measurement_area\n",
     ")"
    ]
   },
@@ -3509,6 +3619,119 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Now the same for a specific measurement area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pedpy import AxisAlignedMeasurementArea, SpeedMethod, compute_speed_profile\n",
+    "\n",
+    "voronoi_speed_profile = compute_speed_profile(\n",
+    "    data=resorted_profile_data_measurement_area,\n",
+    "    walkable_area=walkable_area,\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_intersections_area=grid_cell_intersection_area_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    "    speed_method=SpeedMethod.VORONOI,\n",
+    ")\n",
+    "\n",
+    "arithmetic_speed_profile = compute_speed_profile(\n",
+    "    data=resorted_profile_data_measurement_area,\n",
+    "    walkable_area=walkable_area,\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_intersections_area=grid_cell_intersection_area_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    "    speed_method=SpeedMethod.ARITHMETIC,\n",
+    ")\n",
+    "\n",
+    "mean_speed_profile = compute_speed_profile(\n",
+    "    data=profile_data,\n",
+    "    walkable_area=walkable_area,\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    "    speed_method=SpeedMethod.MEAN,\n",
+    ")\n",
+    "\n",
+    "gauss_speed_profile = compute_speed_profile(\n",
+    "    data=profile_data,\n",
+    "    walkable_area=walkable_area,\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    "    gaussian_width=0.5,\n",
+    "    speed_method=SpeedMethod.GAUSSIAN,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pedpy import plot_profiles\n",
+    "\n",
+    "fig, ((ax0, ax1), (ax2, ax3)) = plt.subplots(nrows=2, ncols=2)\n",
+    "fig.suptitle(\"Speed profile\")\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
+    "    profiles=voronoi_speed_profile,\n",
+    "    axes=ax0,\n",
+    "    label=\"v / m/s\",\n",
+    "    vmin=0,\n",
+    "    vmax=1.5,\n",
+    "    title=\"Voronoi\",\n",
+    ")\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
+    "    profiles=arithmetic_speed_profile,\n",
+    "    axes=ax1,\n",
+    "    label=\"v / m/s\",\n",
+    "    vmin=0,\n",
+    "    vmax=1.5,\n",
+    "    title=\"Arithmetic\",\n",
+    ")\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
+    "    profiles=gauss_speed_profile,\n",
+    "    axes=ax2,\n",
+    "    label=\"v / m/s\",\n",
+    "    vmin=0,\n",
+    "    vmax=1.5,\n",
+    "    title=\"Gauss\",\n",
+    ")\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
+    "    profiles=mean_speed_profile,\n",
+    "    axes=ax3,\n",
+    "    label=\"v / m/s\",\n",
+    "    vmin=0,\n",
+    "    vmax=1.5,\n",
+    "    title=\"Mean\",\n",
+    ")\n",
+    "plt.subplots_adjust(\n",
+    "    left=None, bottom=None, right=None, top=None, wspace=0, hspace=0.6\n",
+    ")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Density Profiles\n",
     "\n",
     "Currently, it is possible to compute either the Voronoi, classic or Gaussian density profiles.\n",
@@ -3634,6 +3857,101 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Now the same for a specific measurement area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pedpy import DensityMethod, compute_density_profile\n",
+    "\n",
+    "# here it is important to use the resorted data, as it needs to be in the same ordering as \"grid_cell_intersection_area\"\n",
+    "voronoi_density_profile = compute_density_profile(\n",
+    "    data=resorted_profile_data_measurement_area,\n",
+    "    walkable_area=walkable_area,\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_intersections_area=grid_cell_intersection_area_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    "    density_method=DensityMethod.VORONOI,\n",
+    ")\n",
+    "\n",
+    "# here the unsorted data can be used\n",
+    "classic_density_profile = compute_density_profile(\n",
+    "    data=profile_data,\n",
+    "    walkable_area=walkable_area,\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    "    density_method=DensityMethod.CLASSIC,\n",
+    ")\n",
+    "\n",
+    "gaussian_density_profile = compute_density_profile(\n",
+    "    data=profile_data,\n",
+    "    walkable_area=walkable_area,\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    "    density_method=DensityMethod.GAUSSIAN,\n",
+    "    gaussian_width=0.5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pedpy import plot_profiles\n",
+    "\n",
+    "fig, (ax0, ax1, ax2) = plt.subplots(nrows=1, ncols=3, layout=\"constrained\")\n",
+    "fig.set_size_inches(12, 5)\n",
+    "fig.suptitle(\"Density profile\")\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
+    "    profiles=voronoi_density_profile,\n",
+    "    axes=ax0,\n",
+    "    label=\"$\\\\rho$ / 1/$m^2$\",\n",
+    "    vmin=0,\n",
+    "    vmax=8,\n",
+    "    title=\"Voronoi\",\n",
+    ")\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
+    "    profiles=classic_density_profile,\n",
+    "    axes=ax1,\n",
+    "    label=\"$\\\\rho$ / 1/$m^2$\",\n",
+    "    vmin=0,\n",
+    "    vmax=8,\n",
+    "    title=\"Classic\",\n",
+    ")\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
+    "    profiles=gaussian_density_profile,\n",
+    "    axes=ax2,\n",
+    "    label=\"$\\\\rho$ / 1/$m^2$\",\n",
+    "    vmin=0,\n",
+    "    vmax=8,\n",
+    "    title=\"Gaussian\",\n",
+    ")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Density and Speed Profiles\n",
     "\n",
     "An other option is to compute both kinds of profile at the same time:"
@@ -3705,6 +4023,86 @@
     ")\n",
     "cm = plot_profiles(\n",
     "    walkable_area=walkable_area,\n",
+    "    profiles=speed_profiles,\n",
+    "    axes=ax1,\n",
+    "    label=\"v / m/s\",\n",
+    "    vmin=0,\n",
+    "    vmax=2,\n",
+    "    title=\"Speed\",\n",
+    ")\n",
+    "fig.tight_layout(pad=2)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now the same for a specific measurement area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pedpy import compute_profiles\n",
+    "\n",
+    "min_frame_profiles = 250  # We use here just an excerpt of the\n",
+    "max_frame_profiles = 400  # trajectory data to reduce compute time\n",
+    "grid_size = 0.4\n",
+    "\n",
+    "density_profiles, speed_profiles = compute_profiles(\n",
+    "    data=pd.merge(\n",
+    "        individual_cutoff[\n",
+    "            individual_cutoff.frame.between(\n",
+    "                min_frame_profiles, max_frame_profiles\n",
+    "            )\n",
+    "        ],\n",
+    "        individual_speed[\n",
+    "            individual_speed.frame.between(\n",
+    "                min_frame_profiles, max_frame_profiles\n",
+    "            )\n",
+    "        ],\n",
+    "        on=[ID_COL, FRAME_COL],\n",
+    "    ),\n",
+    "    walkable_area=walkable_area.polygon,\n",
+    "    axis_aligned_measurement_area=profile_measurement_area,\n",
+    "    grid_size=grid_size,\n",
+    "    speed_method=SpeedMethod.ARITHMETIC,\n",
+    "    density_method=DensityMethod.VORONOI,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pedpy import plot_profiles\n",
+    "\n",
+    "fig, (ax0, ax1) = plt.subplots(nrows=1, ncols=2)\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
+    "    profiles=density_profiles,\n",
+    "    axes=ax0,\n",
+    "    label=\"$\\\\rho$ / 1/$m^2$\",\n",
+    "    vmin=0,\n",
+    "    vmax=12,\n",
+    "    title=\"Density\",\n",
+    ")\n",
+    "cm = plot_profiles(\n",
+    "    walkable_area=walkable_area,\n",
+    "    measurement_area=profile_measurement_area,\n",
     "    profiles=speed_profiles,\n",
     "    axes=ax1,\n",
     "    label=\"v / m/s\",\n",
@@ -4592,7 +4990,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pedpy-313-venv",
+   "display_name": "pedpy-313-venv (3.13.5)",
    "language": "python",
    "name": "python3"
   },
@@ -4606,7 +5004,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/pedpy/__init__.py
+++ b/pedpy/__init__.py
@@ -42,7 +42,12 @@ from .column_identifier import (
     X_COL,
     Y_COL,
 )
-from .data.geometry import MeasurementArea, MeasurementLine, WalkableArea
+from .data.geometry import (
+    AxisAlignedMeasurementArea,
+    MeasurementArea,
+    MeasurementLine,
+    WalkableArea,
+)
 from .data.trajectory_data import TrajectoryData
 from .errors import (
     AccelerationError,
@@ -141,6 +146,7 @@ from .plotting.plotting import (
 )
 
 __all__ = [  # noqa: RUF022 disable sorting of __all__ for better maintenance
+    "AxisAlignedMeasurementArea",
     "MeasurementArea",
     "MeasurementLine",
     "WalkableArea",

--- a/pedpy/data/geometry.py
+++ b/pedpy/data/geometry.py
@@ -199,6 +199,87 @@ class MeasurementArea:
         """
         return self._polygon
 
+    @property
+    def bounds(self):
+        """Minimum bounding region (minx, miny, maxx, maxy).
+
+        Returns:
+            Minimum bounding region (minx, miny, maxx, maxy)
+        """
+        return self._polygon.bounds
+
+
+###############################################################################
+# Axis Aligned MeasurmentArea
+###############################################################################
+class AxisAlignedMeasurementArea(MeasurementArea):
+    """Axis-aligned areas to study pedestrian dynamics.
+
+    An axis aligned measurement area is defined as an area, which is
+    axis-algined, convex, simple, and covers a non-zero area.
+    """
+
+    _frozen = False
+
+    def __init__(self, x_min: float, y_min: float, x_max: float, y_max: float):
+        """Create an axis-aligned measurement area from the given input.
+
+        Creates a rectangular axis-aligned measurement area using the provided
+        coordinates. The resulting area must be valid and have a non-zero area.
+        Raises a GeometryError if the polygon cannot be created or is invalid.
+
+        Args:
+            x_min (float): Minimum x-coordinate of the measurement area.
+            y_min (float): Minimum y-coordinate of the measurement area.
+            x_max (float): Maximum x-coordinate of the measurement area.
+            y_max (float): Maximum y-coordinate of the measurement area.
+
+        Raises:
+            GeometryError: If the measurement area cannot be created or is
+                invalid.
+        """
+        self._polygon = shapely.box(
+            xmin=x_min, ymin=y_min, xmax=x_max, ymax=y_max
+        )
+
+        if self._polygon.area == 0:
+            raise GeometryError(
+                "Axis-aligned measurement area needs to cover a non-zero area."
+            )
+
+        shapely.prepare(self._polygon)
+        self._frozen = True
+
+    @classmethod
+    def from_measurement_area(
+        cls, measurement_area: MeasurementArea
+    ) -> "AxisAlignedMeasurementArea":
+        """Create an AxisAlignedMeasurementArea from a MeasurementArea.
+
+        This method creates an axis-aligned measurement area that bounds the
+        given measurement area. Given the blue measurement area in the
+        following figure, the axis-aligned measurement area is the red rectangle
+        that covers the blue area. The axis-aligned measurement area is defined
+        by the minimum and maximum x and y coordinates of the measurement area.
+
+        .. image:: /images/axis_aligned_measurement_area_from_ma.svg
+            :width: 60 %
+            :align: center
+
+        Args:
+            measurement_area (MeasurementArea): The measurement area from which
+                to create the axis-aligned measurement area.
+
+        Returns:
+            AxisAlignedMeasurementArea: An instance of
+                AxisAlignedMeasurementArea that bounds the given measurement
+                area.
+
+
+        """
+        bounds = measurement_area.bounds
+        return cls(*bounds)
+
 
 ###############################################################################
 # Measurement Line

--- a/pedpy/plotting/plotting.py
+++ b/pedpy/plotting/plotting.py
@@ -40,7 +40,12 @@ from pedpy.column_identifier import (
     X_COL,
     Y_COL,
 )
-from pedpy.data.geometry import MeasurementArea, MeasurementLine, WalkableArea
+from pedpy.data.geometry import (
+    AxisAlignedMeasurementArea,
+    MeasurementArea,
+    MeasurementLine,
+    WalkableArea,
+)
 from pedpy.data.trajectory_data import TrajectoryData
 from pedpy.errors import PedPyRuntimeError
 
@@ -1052,6 +1057,7 @@ def plot_time_distance(  # noqa: PLR0915
 def plot_profiles(
     *,
     walkable_area: WalkableArea,
+    measurement_area: Optional[AxisAlignedMeasurementArea] = None,
     profiles: list[NDArray[np.float64]],
     axes: Optional[matplotlib.axes.Axes] = None,
     **kwargs: Any,
@@ -1060,6 +1066,9 @@ def plot_profiles(
 
     Args:
         walkable_area(WalkableArea): walkable area of the plot
+        measurement_area (MeasurementArea): Measurement area for which the
+            profiles are computed.
+
         profiles(list): List of profiles like speed or density profiles
         axes (matplotlib.axes.Axes): Axes to plot on, if None new will be
             created
@@ -1080,6 +1089,9 @@ def plot_profiles(
         mean_profiles = np.nanmean(profiles, axis=0)
 
     bounds = walkable_area.bounds
+
+    if measurement_area is not None:
+        bounds = measurement_area.bounds
 
     title = kwargs.pop("title", "")
     walkable_color = kwargs.pop("walkable_color", "w")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,6 @@ no_implicit_reexport = true
 strict_equality = true
 warn_redundant_casts = true
 warn_unused_ignores = false
-plugins = ["numpy.typing.mypy_plugin"]
 exclude = "^(helper|docs|scripts|tests)(/|$)"
 
 [[tool.mypy.overrides]]

--- a/tests/unit_tests/methods/test_profile_calculator.py
+++ b/tests/unit_tests/methods/test_profile_calculator.py
@@ -1,0 +1,81 @@
+import pytest
+import shapely
+from shapely.geometry import box
+
+from pedpy.data.geometry import (
+    AxisAlignedMeasurementArea,
+    MeasurementArea,
+    WalkableArea,
+)
+from pedpy.errors import PedPyTypeError, PedPyValueError
+from pedpy.methods.profile_calculator import get_grid_cells
+
+
+def test_get_grid_cells_walkable_area():
+    # Simple 2x2 grid over a 2x2 area with grid_size=1
+    walkable_area = WalkableArea(shapely.box(0, 0, 2, 2))
+    grid_cells, rows, cols = get_grid_cells(
+        walkable_area=walkable_area,
+        grid_size=1.0,
+    )
+    assert rows == 2
+    assert cols == 2
+    assert grid_cells.shape == (4,)
+    # Check that the grid cells are correct shapely boxes
+    expected_boxes = [
+        box(0, 2, 1, 1),
+        box(1, 2, 2, 1),
+        box(0, 1, 1, 0),
+        box(1, 1, 2, 0),
+    ]
+    for cell, expected in zip(grid_cells, expected_boxes, strict=False):
+        assert cell.equals(expected)
+
+
+def test_get_grid_cells_axis_aligned_measurement_area():
+    area = AxisAlignedMeasurementArea(0, 0, 3, 2)
+    grid_cells, rows, cols = get_grid_cells(
+        axis_aligned_measurement_area=area,
+        grid_size=1.0,
+    )
+    assert rows == 2
+    assert cols == 3
+    assert grid_cells.shape == (6,)
+    # Check that the grid cells cover the expected area
+    expected_boxes = [
+        box(0, 2, 1, 1),
+        box(1, 2, 2, 1),
+        box(2, 2, 3, 1),
+        box(0, 1, 1, 0),
+        box(1, 1, 2, 0),
+        box(2, 1, 3, 0),
+    ]
+    for cell, expected in zip(grid_cells, expected_boxes, strict=False):
+        assert cell.equals(expected)
+
+
+def test_get_grid_cells_both_none():
+    with pytest.raises(
+        PedPyValueError,
+        match="Either `walkable_area` or `axis_aligned_measurement_area`",
+    ):
+        get_grid_cells(grid_size=1.0)
+
+
+def test_get_grid_cells_axis_aligned_measurement_area_wrong_type():
+    area = MeasurementArea(shapely.box(0, 0, 1, 1))
+    with pytest.raises(
+        PedPyTypeError,
+        match="AxisAlignedMeasurementArea.from_measurement_area()",
+    ):
+        get_grid_cells(axis_aligned_measurement_area=area, grid_size=1.0)
+
+
+def test_get_grid_cells_axis_aligned_measurement_area_not_instance():
+    with pytest.raises(
+        PedPyTypeError,
+        match="`axis_aligned_measurement_area` must be an instance of AxisAlignedMeasurementArea",
+    ):
+        get_grid_cells(
+            axis_aligned_measurement_area="not_an_area", grid_size=1.0
+        )


### PR DESCRIPTION
Introduces the possibility to compute profiles for a specified axis-aligned measurement area.

For testing this: 

- Install PedPy from the branch:
```
pip install --force-reinstall git+https://github.com/schroedtert/PedPy.git@profiles-for-measurement-area
```

- Take a look at the attached notebook: 
[profiles.ipynb.zip](https://github.com/user-attachments/files/21394387/profiles.ipynb.zip)


Rough overview:

```python
# create axis aligned measurement area
measurement_area = AxisAlignedMeasurmentArea(-1, 0.5, 1, 1.3)

# usual precomputations

# compute profile in measurement area
voronoi_density_profile = compute_density_profile(
    data=resorted_profile_data,
    axis_aligned_measurement_area=measurement_area,
    grid_intersections_area=grid_cell_intersection_area,
    grid_size=grid_size,
    density_method=DensityMethod.VORONOI,
)

# plot result
plot_profiles(
    walkable_area=walkable_area,
    measurement_area=measurement_area,
    profiles=voronoi_density_profile,
    axes=ax0,
    label="$\\rho$ / 1/$m^2$",
    vmin=0,
    vmax=8,
    title="Voronoi",
)

```

<img width="1214" height="511" alt="image" src="https://github.com/user-attachments/assets/e106f9c4-2fff-4008-91c0-07f47e9121af" />

Closes #413 