### PR TITLE
Attach whl and source dist to release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ on:
       - main
       - rls-*
 
+permissions:
+  contents: write
+
 jobs:
   pre-build-checks:
     strategy:
@@ -177,3 +180,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: false


### PR DESCRIPTION
A successful workflow run can be found here: https://github.com/schroedtert/PedPy/actions/runs/16708019921

The release where the artifacts have been attached: https://github.com/schroedtert/PedPy/releases/tag/v0.2.1

Closes #428 
