### PR TITLE
Fix missing titles in profile plots

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,48 +1,48 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.15.10
     hooks:
       - id: ruff
         alias: ruff-include-sorting
         name: Check include sorting (ruff)
-        args: ['check', '--select', 'I', '--fix', '.']
+        args: [ 'check', '--select', 'I', '--fix', '.' ]
       - id: ruff-format
         name: Check formatting (ruff)
-        args: ['.']
+        args: [ '.' ]
       - id: ruff
         alias: ruff-linting
         name: Linting (ruff)
         files: ^pedpy/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: v1.20.0
     hooks:
       - id: mypy
         name: Check type hints (mypy)
         additional_dependencies: [
-            "numpy~=2.1",
-            "pandas~=2.2.3",
-            "Shapely~=2.1",
-            "scipy~=1.14",
-            "matplotlib~=3.9",
-            "h5py~=3.11"
+          "numpy>=2.1,<3.0",
+          "pandas>=2.2,<4.0",
+          "Shapely>=2.1,<3.0",
+          "scipy~=1.15,<2.0",
+          "matplotlib~=3.10,<4.0",
+          "h5py~=3.13,<4.0",
         ]
         exclude: "(^helper/|^docs/|^scripts/|^tests/)"
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.8.1
+    rev: 0.9.1
     hooks:
       - id: nbstripout
         exclude: ^docs/
 
-  -   repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v6.0.0
-      hooks:
-        - id: end-of-file-fixer
-        - id: trailing-whitespace
-        - id: check-yaml
-        - id: check-json
-        - id: check-executables-have-shebangs
-        - id: check-shebang-scripts-are-executable
-        - id: check-symlinks
-        - id: destroyed-symlinks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-json
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: destroyed-symlinks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,7 @@ repos:
     hooks:
       - id: nbstripout
         exclude: ^docs/
+        args: [ '--extra-keys=metadata.kernelspec metadata.language_info' ]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/notebooks/fundamental_diagram.ipynb
+++ b/notebooks/fundamental_diagram.ipynb
@@ -1044,25 +1044,7 @@
    "source": []
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.4"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/notebooks/fundamental_diagram_at_measurement_line.ipynb
+++ b/notebooks/fundamental_diagram_at_measurement_line.ipynb
@@ -913,25 +913,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.7"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -534,25 +534,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.4"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/notebooks/user_guide.ipynb
+++ b/notebooks/user_guide.ipynb
@@ -5186,25 +5186,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv (3.13.7)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.7"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 4
 }

--- a/pedpy/plotting/plotting.py
+++ b/pedpy/plotting/plotting.py
@@ -1324,7 +1324,6 @@ def plot_profiles(
     if axes is None:
         axes = plt.gca()
 
-    axes.set_title(title)
     imshow = axes.imshow(
         mean_profiles,
         extent=(bounds[0], bounds[2], bounds[1], bounds[3]),
@@ -1346,6 +1345,8 @@ def plot_profiles(
         hole_color=hole_color,
         hole_alpha=hole_alpha,
     )
+
+    axes.set_title(title)
 
     return axes
 


### PR DESCRIPTION
One of the more recent changes, did influence the display of the titles of the profile plots, such that they are no longer displayed (https://pedpy.readthedocs.io/latest/user_guide.html#speed-profiles):
<img width="478" height="480" alt="image" src="https://github.com/user-attachments/assets/177c2772-74ac-482b-aa5d-3f3f215a8a3b" />


Before and after (PR preview: https://pedpy--533.org.readthedocs.build/533/user_guide.html#speed-profiles):
<img width="478" height="480" alt="image" src="https://github.com/user-attachments/assets/6ed27f50-4a20-4301-a0d7-09e7719bfd78" />


Also, this is used to update the pre-commit dependencies and stip more meta-data from the committed notebooks.
