### PR TITLE
fix: restore ped_id in acceleration plot legend label

### DIFF
--- a/notebooks/user_guide.ipynb
+++ b/notebooks/user_guide.ipynb
@@ -2834,7 +2834,7 @@
     "plt.title(\"Acceleration time-series of an excerpt of the pedestrians in a specific direction\")\n",
     "for color, ped_id in zip(colors, ped_ids, strict=False):\n",
     "    single_individual_acceleration = individual_acceleration_direction[individual_acceleration_direction.id == ped_id]\n",
-    "    label = \"Ped ID \".format(ped_id)\n",
+    "    label = f\"Ped ID {ped_id}\"\n",
     "    plot_acceleration(\n",
     "        acceleration=single_individual_acceleration,\n",
     "        color=color,\n",


### PR DESCRIPTION
The label was "Ped ID ".format(ped_id), replaced with an f-string so each line is correctly labelled.