### PR TITLE
Add issue template for development tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,27 @@
+---
+name: Task
+about: A development task for PedPy
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Summary
+
+<!-- One or two sentences: what needs to be done and why. -->
+
+## Background / Context
+
+<!-- Why does this task matter? What problem does it solve? Keep it to 3–5 lines. -->
+
+## Technical Details
+
+<!-- Pointers only: relevant files, functions, tools, or constraints. Use a list, no prose. -->
+
+## Acceptance Criteria
+
+<!-- Clear, testable conditions that must all be true for this task to be considered done. Prefer observable outcomes over implementation details. -->
+
+- [ ]
+- [ ]
+- [ ]


### PR DESCRIPTION
Adds an template for development task which have been discussed previously in some meeting or come directly from developers/maintainers of PedPy.