### PR TITLE
Add pre-commit to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
       - dependency-name: "pandas"
         update-types: ["version-update:semver-major"]
 
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      pre-commit-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
For automatic update to the latest versions of the pre-commit hooks, they are now also updated via dependabot on a monthly basis.

This will create such PRs: https://github.com/schroedtert/PedPy/pull/57