### PR TITLE
Fix duplicate columns in plot_voronoi_cells

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: mypy
         name: Check type hints (mypy)
         additional_dependencies: [
-          "numpy>=2.1,<3.0",
+          "numpy>=2.1,<2.5",
           "pandas>=3.0,<4.0",
           "Shapely>=2.1,<3.0",
           "scipy~=1.15,<2.0",

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -11,6 +11,7 @@ Version 1.6.0 (YYYY-MM-DD)
 
 **Fixes:**
 
+- Fix duplicate columns in :code:`plot_voronoi_cells`: When plotting Voronoi cells, the function now correctly handles cases where duplicate columns may arise in the output DataFrame, ensuring that each column is unique and accurately represents the corresponding data.
 
 Version 1.5.0 (2026-06-02)
 ==========================

--- a/pedpy/plotting/plotting.py
+++ b/pedpy/plotting/plotting.py
@@ -1838,8 +1838,9 @@ def plot_voronoi_cells(  # noqa: PLR0912,PLR0915
         plot_measurement_setup(measurement_areas=[measurement_area], axes=axes, **kwargs)
 
     if traj_data:
-        data = traj_data.data.merge(
-            voronoi_data[voronoi_data.frame == frame],
+        frame_data = voronoi_data[voronoi_data.frame == frame].drop(columns=[X_COL, Y_COL], errors="ignore")
+        data = frame_data.merge(
+            traj_data.data[[ID_COL, FRAME_COL, X_COL, Y_COL]],
             on=[ID_COL, FRAME_COL],
         )
     else:


### PR DESCRIPTION
Merging the full traj_data.data into voronoi_data produced _x/_y
suffixed columns whenever voronoi_data already carried x/y (e.g. when
the caller had pre-merged trajectory positions into it), breaking
downstream lookups of X_COL/Y_COL. traj_data is now treated as the
source of truth for positions, with any existing x/y dropped from
voronoi_data before merging.

Closes #560 