### PR TITLE
Add lane formation order parameter

### DIFF
--- a/notebooks/user_guide.ipynb
+++ b/notebooks/user_guide.ipynb
@@ -4497,6 +4497,167 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Lane order parameter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In bi-directional flow, pedestrians moving in opposite directions tend to segregate into lanes. The lane order parameter $\\Phi$ quantifies how far this segregation has progressed, using positions only. \n",
+    "\n",
+    "For each pedestrian $i$, all pedestrians within a lateral distance $\\gamma$ are counted, split into those moving the same way ($N_L$, including $i$ itself) and those moving against ($N_O$):\n",
+    "\n",
+    "$$\\varphi_i = \\frac{(N_L - N_O)^2}{(N_L + N_O)^2}, \\qquad \\Phi = \\frac{1}{N}\\sum_i \\varphi_i$$\n",
+    "\n",
+    "$\\varphi_i = 1$ when a pedestrian shares its stripe only with pedestrians going the same way, and $0$ when the stripe is evenly mixed. The squaring makes the measure indifferent to which species dominates.\n",
+    "\n",
+    "The measure was introduced for pedestrian dynamics by [Nowak and Schadschneider (2012)](https://doi.org/10.1103/PhysRevE.85.066128), adapting an order parameter from colloidal suspensions, and generalised to continuous space by [von Krüchten (2019)](https://kups.ub.uni-koeln.de/10361/), whose $\\gamma$ threshold replaces the lattice row of the original.\n",
+    "\n",
+    "The perpendicular coordinate is assumed to be $y$, so the corridor must run parallel to the $x$-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "\n",
+    "from pedpy import TrajectoryUnit, load_trajectory_from_txt\n",
+    "\n",
+    "bi_file = pathlib.Path(\"demo-data/bi-directional/bi_corr_400_b_03.txt\")\n",
+    "traj_bi = load_trajectory_from_txt(\n",
+    "    trajectory_file=bi_file,\n",
+    "    default_unit=TrajectoryUnit.CENTIMETER,\n",
+    ")\n",
+    "print(f\"{traj_bi.number_pedestrians = }\")\n",
+    "print(f\"{traj_bi.bounds = }\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The bounds printed above give the extent of the trajectories as $(x_{\\min}, y_{\\min}, x_{\\max}, y_{\\max})$: here about 10 m along $x$ and 4 m along $y$, confirming that this corridor is oriented as the measure requires."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Every measure so far in this notebook that used species considers pedestrians *at* the line, which is exactly the set `compute_species` classifies. $\\Phi$ needs a direction for every pedestrian in every frame, to classify them into two species ($+1$ for those who start from the left end of the corridor to the right end, and $-1$ for the opposite case). \n",
+    "\n",
+    "`compute_species` cannot supply that, since it assigns a species only to pedestrians whose Voronoi cell reaches the measurement line and leaves the rest out of its result. Those pedestrians would be skipped (with no direction of their own), and additionally they would be counted as opponents by everyone sharing their stripe, thereby lowering the value of $\\Phi$.\n",
+    "\n",
+    "In this experiment each participant walks the length of the corridor once, so the sign of their net displacement along $x$ gives the target direction directly, for everyone. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pedpy import FRAME_COL, ID_COL, X_COL\n",
+    "\n",
+    "ordered = traj_bi.data.sort_values([ID_COL, FRAME_COL])\n",
+    "net_displacement = ordered.groupby(ID_COL)[X_COL].last() - ordered.groupby(ID_COL)[X_COL].first()\n",
+    "\n",
+    "species_bi = pd.DataFrame(\n",
+    "    {ID_COL: net_displacement.index, \"species\": np.sign(net_displacement).astype(int)}\n",
+    ").reset_index(drop=True)\n",
+    "\n",
+    "print(species_bi[\"species\"].value_counts())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The threshold $\\gamma$ sets how far apart two pedestrians may be laterally and still count as sharing a lane. A common choice is $\\gamma = \\frac{3}{2}r$ with $r$ the pedestrian radius, giving $\\gamma = 0.225\\,\\text{m}$ for $r = 0.15\\,\\text{m}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from pedpy import (\n",
+    "    FRAME_COL,\n",
+    "    ID_COL,\n",
+    "    ORDER_PARAMETER_COL,\n",
+    "    PEDPY_ORANGE,\n",
+    "    PEDPY_PETROL,\n",
+    "    compute_lane_order_parameter,\n",
+    ")\n",
+    "\n",
+    "gamma = 0.225  # 3r/2 for r = 0.15 m\n",
+    "\n",
+    "phi_bi = compute_lane_order_parameter(\n",
+    "    traj_data=traj_bi,\n",
+    "    species=species_bi,\n",
+    "    gamma=gamma,\n",
+    ")\n",
+    "\n",
+    "occupancy = traj_bi.data.groupby(FRAME_COL)[ID_COL].nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig_phi, ax_phi = plt.subplots(figsize=(9, 4))\n",
+    "ax_phi.plot(\n",
+    "    phi_bi[FRAME_COL],\n",
+    "    phi_bi[ORDER_PARAMETER_COL],\n",
+    "    color=PEDPY_PETROL,\n",
+    "    label=r\"$\\Phi$\",\n",
+    ")\n",
+    "ax_phi.set_xlabel(\"Frame\")\n",
+    "ax_phi.set_ylabel(r\"$\\Phi$\")\n",
+    "ax_phi.set_ylim(0, 1.05)\n",
+    "\n",
+    "ax_n = ax_phi.twinx()\n",
+    "ax_n.plot(\n",
+    "    occupancy.index,\n",
+    "    occupancy.to_numpy(),\n",
+    "    color=PEDPY_ORANGE,\n",
+    "    linestyle=\"--\",\n",
+    "    alpha=0.6,\n",
+    "    label=\"pedestrians in corridor\",\n",
+    ")\n",
+    "ax_n.set_ylabel(\"pedestrians in corridor\")\n",
+    "\n",
+    "fig_phi.legend(loc=\"upper right\", bbox_to_anchor=(0.9, 0.32))\n",
+    "fig_phi.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{important}\n",
+    "$\\Phi$ tends to $1$ at low densities, regardless of whether lanes are present.\n",
+    "A pedestrian with nobody within $\\gamma$ has $N_L = 1$ and $N_O = 0$, hence\n",
+    "$\\varphi_i = 1$. In the plot above this is visible while the corridor fills and\n",
+    "empties, which is why the number of pedestrians is shown alongside.\n",
+    "[Nowak and Schadschneider (2012)](https://doi.org/10.1103/PhysRevE.85.066128)\n",
+    "propose a reduced parameter correcting for this, which is not implemented here.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "jupyter": {
      "outputs_hidden": false

--- a/notebooks/user_guide.ipynb
+++ b/notebooks/user_guide.ipynb
@@ -4612,7 +4612,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "fig_phi, ax_phi = plt.subplots(figsize=(9, 4))\n",

--- a/pedpy/__init__.py
+++ b/pedpy/__init__.py
@@ -31,6 +31,7 @@ from .column_identifier import (
     MID_POSITION_COL,
     NEIGHBORS_COL,
     NEIGHBOR_ID_COL,
+    ORDER_PARAMETER_COL,
     POINT_COL,
     POLYGON_COL,
     SPEED_COL,
@@ -117,7 +118,10 @@ from .methods.profile_calculator import (
     compute_speed_profile,
     get_grid_cells,
 )
-from .methods.spatial_analysis import compute_pair_distribution_function
+from .methods.spatial_analysis import (
+    compute_lane_order_parameter,
+    compute_pair_distribution_function,
+)
 from .methods.speed_calculator import (
     compute_individual_speed,
     compute_line_speed,
@@ -195,6 +199,7 @@ __all__ = [  # noqa: RUF022 disable sorting of __all__ for better maintenance
     "is_species_valid",
     "is_trajectory_valid",
     "compute_pair_distribution_function",
+    "compute_lane_order_parameter",
     "DensityMethod",
     "RsetMethod",
     "SpeedMethod",
@@ -271,6 +276,7 @@ __all__ = [  # noqa: RUF022 disable sorting of __all__ for better maintenance
     "MID_POSITION_COL",
     "END_POSITION_COL",
     "WINDOW_SIZE_COL",
+    "ORDER_PARAMETER_COL",
     "__version__",
     "AccelerationError",
     "GeometryError",

--- a/pedpy/column_identifier.py
+++ b/pedpy/column_identifier.py
@@ -44,3 +44,5 @@ SPEED_SP1_COL: Final = "s_sp+1"
 SPEED_SP2_COL: Final = "s_sp-1"
 FLOW_SP1_COL: Final = "j_sp+1"
 FLOW_SP2_COL: Final = "j_sp-1"
+
+ORDER_PARAMETER_COL: Final = "order_parameter"

--- a/pedpy/methods/spatial_analysis.py
+++ b/pedpy/methods/spatial_analysis.py
@@ -11,7 +11,14 @@ import numpy.typing as npt
 import pandas as pd
 from scipy.spatial.distance import cdist
 
-from pedpy.column_identifier import FRAME_COL, ID_COL, X_COL, Y_COL
+from pedpy.column_identifier import (
+    FRAME_COL,
+    ID_COL,
+    ORDER_PARAMETER_COL,
+    SPECIES_COL,
+    X_COL,
+    Y_COL,
+)
 from pedpy.data.trajectory_data import TrajectoryData
 from pedpy.methods.method_utils import _check_trajectory_data
 
@@ -133,3 +140,118 @@ def _calculate_pair_distances(
             distances_list.extend(distances_upper_triangle)
 
     return np.array(distances_list)
+
+
+def compute_lane_order_parameter(
+    *,
+    traj_data: TrajectoryData,
+    species: pd.DataFrame,
+    gamma: float,
+) -> pd.DataFrame:
+    r"""Computes the order parameter for lane formation.
+
+    The order parameter :math:`\Phi` indicates which fraction of the
+    pedestrians walks in a lane. It was introduced for pedestrian dynamics
+    by Nowak and Schadschneider (2012), adapting an order parameter used
+    for colloidal suspensions, and extended to continuous space by
+    von Krüchten (2019). Two pedestrians are considered to be in the same
+    lane when their distance perpendicular to the desired walking direction
+    is below a threshold :math:`\gamma`:
+
+    .. math::
+        |y_n(t) - y_i(t)| \le \gamma
+
+    With :math:`N_L` the number of pedestrians meeting this criterion and
+    walking in the same direction as pedestrian :math:`i`, and :math:`N_O`
+    the number walking in the opposite direction, the order parameter of a
+    single pedestrian is
+
+    .. math::
+        \varphi_i = \frac{(N_L - N_O)^2}{(N_L + N_O)^2}
+
+    which is zero when both directions are equally represented and tends to
+    one when the lane is dominated by a single direction. The global order
+    parameter is the average over all :math:`N` pedestrians in the frame:
+
+    .. math::
+        \Phi = \frac{1}{N} \sum_{i=1}^{N} \varphi_i
+
+    Pedestrian :math:`i` is counted as its own lane mate, hence
+    :math:`N_L \ge 1` and the denominator never vanishes. An isolated
+    pedestrian therefore yields :math:`\varphi_i = 1`.
+
+    .. note::
+
+        The perpendicular coordinate is taken to be :math:`y`, i.e., the
+        desired walking direction is assumed to be parallel to the x-axis.
+
+    .. warning::
+
+        :math:`\Phi` approaches one as the number of pedestrians decreases,
+        since an isolated pedestrian is trivially in a lane of its own.
+        Values computed at different densities are therefore not directly
+        comparable. Nowak and Schadschneider (2012) address this with a
+        reduced order parameter, which subtracts the value expected for a
+        random configuration at the same density. This is not implemented
+        here.
+
+    Args:
+        traj_data (TrajectoryData): trajectory data
+        species (pd.DataFrame): DataFrame containing the columns 'id' and
+            'species', where the species is +1 or -1 and denotes the desired
+            walking direction, result from
+            :func:`~speed_calculator.compute_species`
+        gamma (float): threshold in :math:`m` below which two pedestrians
+            are considered to be in the same lane. Following von Krüchten
+            (2019) a value of :math:`3r/2` is used, with :math:`r` the
+            radius of a pedestrian.
+
+    Returns:
+        DataFrame containing the columns 'frame' and 'order_parameter'.
+    """
+    _check_trajectory_data(traj_data)
+
+    data_with_species = traj_data.data.merge(species, on=ID_COL, how="left")
+
+    order_parameter_per_frame = []
+    for frame, frame_df in data_with_species.groupby(FRAME_COL):
+        order_parameter_per_frame.append(
+            {
+                FRAME_COL: frame,
+                ORDER_PARAMETER_COL: _compute_frame_order_parameter(
+                    y_values=frame_df[Y_COL].to_numpy(),
+                    species_values=frame_df[SPECIES_COL].to_numpy(),
+                    gamma=gamma,
+                ),
+            }
+        )
+
+    return pd.DataFrame(order_parameter_per_frame)
+
+
+def _compute_frame_order_parameter(
+    *,
+    y_values: npt.NDArray[np.float64],
+    species_values: npt.NDArray[np.float64],
+    gamma: float,
+) -> float:
+    """Computes the order parameter for a single frame.
+
+    Args:
+        y_values: coordinates perpendicular to the walking direction
+        species_values: species (+1 or -1) of each pedestrian
+        gamma: threshold below which two pedestrians share a lane
+
+    Returns:
+        The order parameter of the frame.
+    """
+    lateral_distance = np.abs(y_values[:, np.newaxis] - y_values[np.newaxis, :])
+    in_lane = lateral_distance <= gamma
+    same_species = species_values[:, np.newaxis] == species_values[np.newaxis, :]
+
+    # the pedestrian itself is included, hence num_same_lane >= 1
+    num_same_lane = np.count_nonzero(in_lane & same_species, axis=1)
+    num_opposite_lane = np.count_nonzero(in_lane & ~same_species, axis=1)
+
+    order_parameter_individual = ((num_same_lane - num_opposite_lane) ** 2) / ((num_same_lane + num_opposite_lane) ** 2)
+    return float(np.mean(order_parameter_individual))

--- a/pedpy/methods/spatial_analysis.py
+++ b/pedpy/methods/spatial_analysis.py
@@ -151,7 +151,7 @@ def compute_lane_order_parameter(
 ) -> pd.DataFrame:
     r"""Computes the order parameter for lane formation.
 
-    The order parameter :math:\Phi quantifies how strongly pedestrians
+    The order parameter :math:`\Phi` quantifies how strongly pedestrians
     moving in opposite directions have segregated into lanes. It was
     introduced for pedestrian dynamics by Nowak and Schadschneider (2012),
     adapting an order parameter used for colloidal suspensions, and extended

--- a/pedpy/methods/spatial_analysis.py
+++ b/pedpy/methods/spatial_analysis.py
@@ -20,6 +20,7 @@ from pedpy.column_identifier import (
     Y_COL,
 )
 from pedpy.data.trajectory_data import TrajectoryData
+from pedpy.errors import PedPyValueError
 from pedpy.methods.method_utils import _check_trajectory_data
 
 
@@ -150,13 +151,13 @@ def compute_lane_order_parameter(
 ) -> pd.DataFrame:
     r"""Computes the order parameter for lane formation.
 
-    The order parameter :math:`\Phi` indicates which fraction of the
-    pedestrians walks in a lane. It was introduced for pedestrian dynamics
-    by Nowak and Schadschneider (2012), adapting an order parameter used
-    for colloidal suspensions, and extended to continuous space by
-    von Krüchten (2019). Two pedestrians are considered to be in the same
-    lane when their distance perpendicular to the desired walking direction
-    is below a threshold :math:`\gamma`:
+    The order parameter :math:\Phi quantifies how strongly pedestrians
+    moving in opposite directions have segregated into lanes. It was
+    introduced for pedestrian dynamics by Nowak and Schadschneider (2012),
+    adapting an order parameter used for colloidal suspensions, and extended
+    to continuous space by von Krüchten (2019). Two pedestrians are considered
+    to be in the same lane when their distance perpendicular to the desired
+    walking direction is below a threshold :math:`\gamma`:
 
     .. math::
         |y_n(t) - y_i(t)| \le \gamma
@@ -184,6 +185,15 @@ def compute_lane_order_parameter(
 
         The perpendicular coordinate is taken to be :math:`y`, i.e., the
         desired walking direction is assumed to be parallel to the x-axis.
+        For geometries other than a bidirectional corridor, :math:`\Phi`
+        is computed but is not meaningful. Only the single-species case
+        below is detectable by the function itself.
+
+    .. note::
+
+        With only one species present, :math:`N_O = 0` for every pedestrian
+        and :math:`\Phi = 1` in every frame, independent of the positions.
+        A warning is issued in this case.
 
     .. warning::
 
@@ -199,17 +209,46 @@ def compute_lane_order_parameter(
         traj_data (TrajectoryData): trajectory data
         species (pd.DataFrame): DataFrame containing the columns 'id' and
             'species', where the species is +1 or -1 and denotes the desired
-            walking direction, result from
-            :func:`~speed_calculator.compute_species`
+            walking direction. A species is required for every pedestrian in
+            the trajectory data. Note that
+            :func:`~speed_calculator.compute_species` assigns a species only
+            to pedestrians whose Voronoi cell intersects the measurement
+            line, so it may not cover the whole population.
         gamma (float): threshold in :math:`m` below which two pedestrians
             are considered to be in the same lane. Following von Krüchten
             (2019) a value of :math:`3r/2` is used, with :math:`r` the
             radius of a pedestrian.
 
+    Raises:
+        PedPyValueError: if a pedestrian has more than one species assigned,
+            if a pedestrian in the trajectory data has no species assigned,
+            or if a species other than -1 or 1 is present.
+
     Returns:
         DataFrame containing the columns 'frame' and 'order_parameter'.
     """
     _check_trajectory_data(traj_data)
+
+    if species[ID_COL].duplicated().any():
+        raise PedPyValueError("Every pedestrian may only have one species assigned.")
+
+    missing_ids = set(traj_data.data[ID_COL].unique()) - set(species[ID_COL])
+    if missing_ids:
+        raise PedPyValueError(
+            f"No species assigned for {len(missing_ids)} pedestrians, "
+            "every pedestrian in the trajectory data needs a species."
+        )
+
+    invalid_species = set(species[SPECIES_COL].unique()) - {-1, 1}
+    if invalid_species:
+        raise PedPyValueError(f"Only species -1 and 1 are supported, found {sorted(invalid_species, key=repr)}.")
+
+    if species[SPECIES_COL].nunique() < 2:
+        warning_message = (
+            "Only one species is present, the order parameter will be 1 in "
+            "every frame, independent of the pedestrians' positions."
+        )
+        warnings.warn(warning_message, stacklevel=2)
 
     data_with_species = traj_data.data.merge(species, on=ID_COL, how="left")
 

--- a/tests/unit_tests/methods/test_lane_order_parameter.py
+++ b/tests/unit_tests/methods/test_lane_order_parameter.py
@@ -1,10 +1,13 @@
 """Unit tests for compute_lane_order_parameter in pedpy.methods.spatial_analysis."""
 
+import warnings
+
 import pandas as pd
 import pytest
 from tests.utils.utils import make_traj
 
 from pedpy.column_identifier import FRAME_COL, ORDER_PARAMETER_COL
+from pedpy.errors import PedPyValueError
 from pedpy.methods.spatial_analysis import compute_lane_order_parameter
 
 GAMMA = 0.225  # 3r/2 with r = 0.15 m, the value used by von Kruechten (2019)
@@ -65,12 +68,15 @@ def test_lane_order_parameter_single_pedestrian():
 
     Each pedestrian is counted as its own lane mate, so the number of
     same-direction lane mates is at least one and the denominator never
-    vanishes. An isolated pedestrian therefore scores one.
+    vanishes. An isolated pedestrian therefore scores one. With only one
+    pedestrian there is also only one species, so the single-species
+    warning is expected here.
     """
     traj = make_traj(ids=[0], frames=[0], xs=[0.0], ys=[1.5])
     species = make_species(ids=[0], species=[1.0])
 
-    result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+    with pytest.warns(UserWarning, match="Only one species"):
+        result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
 
     assert result[ORDER_PARAMETER_COL].iloc[0] == pytest.approx(1.0)
 
@@ -160,3 +166,73 @@ def test_lane_order_parameter_returns_one_row_per_frame():
 
     assert list(result[FRAME_COL]) == [0, 1]
     assert result[ORDER_PARAMETER_COL].to_list() == pytest.approx([0.0, 1.0])
+
+
+def test_duplicate_species_raises():
+    """A pedestrian listed twice in the species frame is rejected.
+
+    The merge would otherwise duplicate that pedestrian's row in every
+    frame, silently adding a phantom pedestrian.
+    """
+    traj = make_traj(ids=[0, 1], frames=[0, 0], xs=[0.0, 1.0], ys=[0.5, 2.5])
+    species = make_species(ids=[0, 0, 1], species=[1.0, -1.0, -1.0])
+
+    with pytest.raises(PedPyValueError, match="only have one species"):
+        compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+
+def test_missing_species_raises():
+    """A pedestrian absent from the species frame is rejected.
+
+    Such a pedestrian would get a NaN species, which compares unequal to
+    everything and makes them an opponent to all.
+    """
+    traj = make_traj(ids=[0, 1, 2], frames=[0, 0, 0], xs=[0.0, 1.0, 2.0], ys=[0.5, 2.5, 0.5])
+    species = make_species(ids=[0, 1], species=[1.0, -1.0])
+
+    with pytest.raises(PedPyValueError, match="No species assigned"):
+        compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+
+def test_invalid_species_value_raises():
+    """A species other than -1 or 1 is rejected.
+
+    compute_species returns np.sign of the speed, which is zero for a
+    pedestrian at rest, so a species of zero is a reachable input.
+    """
+    traj = make_traj(ids=[0, 1], frames=[0, 0], xs=[0.0, 1.0], ys=[0.5, 2.5])
+    species = make_species(ids=[0, 1], species=[1.0, 0.0])
+
+    with pytest.raises(PedPyValueError, match="Only species -1 and 1"):
+        compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+
+def test_single_species_warns_and_returns_one():
+    """With one species N_O vanishes for everyone, so Phi is one by algebra.
+
+    Pedestrians 0 and 1 share a lane, pedestrian 2 is isolated, so the result
+    holds both for pedestrians with lane mates and without. Two frames are
+    used to check the degeneracy holds across the whole output.
+    """
+    traj = make_traj(
+        ids=[0, 1, 2, 0, 1, 2],
+        frames=[0, 0, 0, 1, 1, 1],
+        xs=[0.0, 1.0, 2.0, 0.1, 1.1, 2.1],
+        ys=[0.5, 0.6, 3.0, 0.5, 0.6, 3.0],
+    )
+    species = make_species(ids=[0, 1, 2], species=[1.0, 1.0, 1.0])
+
+    with pytest.warns(UserWarning, match="Only one species"):
+        result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+    assert result[ORDER_PARAMETER_COL].iloc[0] == pytest.approx(1.0)
+
+
+def test_valid_input_does_not_warn():
+    """Two well-formed species must not trigger the single-species warning."""
+    traj = make_traj(ids=[0, 1], frames=[0, 0], xs=[0.0, 1.0], ys=[0.5, 2.5])
+    species = make_species(ids=[0, 1], species=[1.0, -1.0])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)

--- a/tests/unit_tests/methods/test_lane_order_parameter.py
+++ b/tests/unit_tests/methods/test_lane_order_parameter.py
@@ -1,0 +1,162 @@
+"""Unit tests for compute_lane_order_parameter in pedpy.methods.spatial_analysis."""
+
+import pandas as pd
+import pytest
+from tests.utils.utils import make_traj
+
+from pedpy.column_identifier import FRAME_COL, ORDER_PARAMETER_COL
+from pedpy.methods.spatial_analysis import compute_lane_order_parameter
+
+GAMMA = 0.225  # 3r/2 with r = 0.15 m, the value used by von Kruechten (2019)
+
+
+def make_species(ids: list[int], species: list[float]) -> pd.DataFrame:
+    """Builds a species DataFrame from parallel lists."""
+    return pd.DataFrame({"id": ids, "species": species})
+
+
+def test_lane_order_parameter_perfect_lanes():
+    """Four pedestrians at y=0.5 walking right, four at y=2.5 walking left.
+
+    The two groups are further apart than gamma, so no pedestrian has an
+    opposite-direction lane mate and every individual value is one.
+    """
+    traj = make_traj(
+        ids=[0, 1, 2, 3, 4, 5, 6, 7],
+        frames=[0] * 8,
+        xs=[0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0],
+        ys=[0.5, 0.5, 0.5, 0.5, 2.5, 2.5, 2.5, 2.5],
+    )
+    species = make_species(
+        ids=[0, 1, 2, 3, 4, 5, 6, 7],
+        species=[1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0],
+    )
+
+    result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+    assert len(result) == 1
+    assert result[ORDER_PARAMETER_COL].iloc[0] == pytest.approx(1.0)
+
+
+def test_lane_order_parameter_perfect_mixing():
+    """Four pedestrians walking right, four walking left, all at y=1.5.
+
+    There are equal number of in-lane and opposite-lane mates, so every individual value becomes zero.
+    """
+    traj = make_traj(
+        ids=[0, 1, 2, 3, 4, 5, 6, 7],
+        frames=[0] * 8,
+        xs=[0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0],
+        ys=[1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5],
+    )
+    species = make_species(
+        ids=[0, 1, 2, 3, 4, 5, 6, 7],
+        species=[1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0],
+    )
+
+    result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+    assert len(result) == 1
+    assert result[ORDER_PARAMETER_COL].iloc[0] == pytest.approx(0.0)
+
+
+def test_lane_order_parameter_single_pedestrian():
+    """A single pedestrian yields one.
+
+    Each pedestrian is counted as its own lane mate, so the number of
+    same-direction lane mates is at least one and the denominator never
+    vanishes. An isolated pedestrian therefore scores one.
+    """
+    traj = make_traj(ids=[0], frames=[0], xs=[0.0], ys=[1.5])
+    species = make_species(ids=[0], species=[1.0])
+
+    result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+    assert result[ORDER_PARAMETER_COL].iloc[0] == pytest.approx(1.0)
+
+
+def test_lane_order_parameter_is_blind_to_which_direction_dominates():
+    """Three pedestrians walking right and one walking left, all at y=1.5.
+
+    Every pedestrian sees the same four lane mates, so the majority
+    pedestrians have (3 - 1)^2 / (3 + 1)^2 and the single opposing one has
+    (1 - 3)^2 / (1 + 3)^2. Squaring makes these equal, and the mean is 0.25.
+    """
+    traj = make_traj(
+        ids=[0, 1, 2, 3],
+        frames=[0] * 4,
+        xs=[0.0, 1.0, 2.0, 3.0],
+        ys=[1.5] * 4,
+    )
+    species = make_species(ids=[0, 1, 2, 3], species=[1.0, 1.0, 1.0, -1.0])
+
+    result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+    assert result[ORDER_PARAMETER_COL].iloc[0] == pytest.approx(0.25)
+
+
+def test_lane_order_parameter_is_one_for_sparse_counterflow():
+    """Two pedestrians in counterflow, further apart than gamma, yield one.
+
+    Neither pedestrian is a lane mate of the other, so both score one even
+    though no lanes have formed. This is the reason values obtained at
+    different densities are not directly comparable.
+    """
+    traj = make_traj(ids=[0, 1], frames=[0, 0], xs=[0.0, 1.0], ys=[0.5, 2.5])
+    species = make_species(ids=[0, 1], species=[1.0, -1.0])
+
+    result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+    assert result[ORDER_PARAMETER_COL].iloc[0] == pytest.approx(1.0)
+
+
+def test_lane_order_parameter_ignores_longitudinal_distance():
+    """Pedestrians far apart along the corridor still count as lane mates.
+
+    The lane criterion constrains only the distance perpendicular to the
+    walking direction, so a lane extends over the full length of the
+    geometry. Here the two groups are 45 m apart and cannot interact, yet
+    the result is the same as if they stood next to each other.
+
+    This follows the definition of the order parameter and is intended
+    behaviour, but it means the measure can misreport the state of the
+    system: here it registers a fully mixed lane, when in fact the two
+    groups are too far apart to interact at all. The lane criterion sees
+    only the perpendicular coordinate, so it cannot distinguish a genuine
+    lane from pedestrians who merely happen to share a height.
+    """
+    traj = make_traj(
+        ids=[0, 1, 2, 3, 4, 5, 6, 7],
+        frames=[0] * 8,
+        xs=[0.0, 1.0, 2.0, 3.0, 45.0, 46.0, 47.0, 48.0],
+        ys=[1.5] * 8,
+    )
+    species = make_species(
+        ids=[0, 1, 2, 3, 4, 5, 6, 7],
+        species=[1.0, 1.0, 1.0, 1.0, -1.0, -1.0, -1.0, -1.0],
+    )
+
+    result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+    assert result[ORDER_PARAMETER_COL].iloc[0] == pytest.approx(0.0)
+
+
+def test_lane_order_parameter_returns_one_row_per_frame():
+    """Two frames in which four pedestrians rearrange from mixed to sorted.
+
+    In frame 0 all four share a height and the two directions are equally
+    represented, in frame 1 they have separated into two lanes further
+    apart than gamma.
+    """
+    traj = make_traj(
+        ids=[0, 1, 2, 3, 0, 1, 2, 3],
+        frames=[0, 0, 0, 0, 1, 1, 1, 1],
+        xs=[2.0, 2.5, 3.0, 3.5, 2.0, 2.5, 3.0, 3.5],
+        ys=[1.5, 1.5, 1.5, 1.5, 0.5, 0.5, 2.5, 2.5],
+    )
+    species = make_species(ids=[0, 1, 2, 3], species=[1.0, 1.0, -1.0, -1.0])
+
+    result = compute_lane_order_parameter(traj_data=traj, species=species, gamma=GAMMA)
+
+    assert list(result[FRAME_COL]) == [0, 1]
+    assert result[ORDER_PARAMETER_COL].to_list() == pytest.approx([0.0, 1.0])


### PR DESCRIPTION
Implements the lane formation order parameter from #507.

`compute_lane_order_parameter` returns Phi per frame from a trajectory and a
species DataFrame. Seven unit tests cover the hand-computable cases.

A few decisions I'd like your view on:

**Placement.** I put it in `spatial_analysis.py`, next to the pair
distribution function, since it is also a pairwise structural measure and
fits none of density/speed/flow/profiles. Happy to move it.

**Species as an argument.** The walking direction is passed in rather than
computed internally, since the order parameter needs neither Voronoi cells
nor a measurement line. Users with simulation output can build the two
columns directly.

**Self-counting.** Each pedestrian counts itself as a lane mate, so N_L >= 1
and the denominator cannot vanish; an isolated pedestrian scores 1. Neither
Nowak and Schadschneider nor von Krüchten state this explicitly, but the
alternative divides by zero. Four of the tests pin this down.

**Perpendicular coordinate.** Hard-coded to y, i.e. the corridor is assumed
parallel to the x-axis. 

**Not included:** the reduced order parameter (Nowak and Schadschneider Eq.
12), which corrects for the density dependence of Phi. The docstring warns
about this. It needs a numerical baseline over shuffled species labels, so
it seemed better as a separate PR.


Closes #507 